### PR TITLE
feat: locale (Accept-Language) localization — honest scope for #130

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ShowRef` for albums/shows). `total` is Spotify's track-match count (`None`
   when tracks aren't requested). A no-match query returns empty results, not an
   error; an unrecognized type raises `URLError` before any request.
+- **Display-language localization.** An optional `locale` (a BCP-47 language tag
+  such as `"de"` or `"ja-JP"`) on the constructor and on every entity getter and
+  `search()` sets the `Accept-Language` header so Spotify returns localized
+  display names (per-call overrides the per-client default; invalid tags raise
+  `URLError` before any request). `locale` is a *language* preference, not a
+  country/market code — a bare `"US"` is ignored — and does not filter regional
+  availability; anonymous market filtering is intentionally not offered (the
+  pathfinder `market` variable is inert and country is IP-bound).
 
 ## [3.2.0] - 2026-06-13
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,26 @@ with SpotifyClient() as client:
     client.download_preview(track, dest="previews/", embed_cover=True)  # needs [media]
 ```
 
+### Localized display names
+
+Pass `locale` — an ISO-3166 alpha-2 code (`"DE"`) or a language tag (`"ja-JP"`) —
+to localize the *language* of display names. Set it per client or override it per
+call:
+
+```python
+with SpotifyClient(locale="ja-JP") as client:        # default for every call
+    track = client.get_track("4uLU6hMCjMI75M1A2tKUQC")
+    other = client.get_track("4uLU6hMCjMI75M1A2tKUQC", locale="de-DE")  # per-call wins
+```
+
+It is sent as the `Accept-Language` header and changes only how names are
+*spelled*. It does **not** filter regional **availability** or vary **preview
+URLs** — anonymous Spotify resolves country from the request IP, and its
+pathfinder silently ignores a `market` variable. True market/availability
+filtering requires the authenticated Web API, which this library does not
+implement; for region-specific results, point the client's `proxy` at the
+target region.
+
 ## Features
 
 - **All core entities + podcasts** — tracks, albums, artists, playlists, shows, episodes.

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ with SpotifyClient() as client:
 
 ### Localized display names
 
-Pass `locale` — an ISO-3166 alpha-2 code (`"DE"`) or a language tag (`"ja-JP"`) —
-to localize the *language* of display names. Set it per client or override it per
-call:
+Pass `locale` — a BCP-47 **language** tag: a bare language subtag (`"de"`,
+`"ja"`) or a language-region tag (`"ja-JP"`) — to localize the *language* of
+display names. Set it per client or override it per call:
 
 ```python
 with SpotifyClient(locale="ja-JP") as client:        # default for every call
@@ -88,12 +88,14 @@ with SpotifyClient(locale="ja-JP") as client:        # default for every call
 ```
 
 It is sent as the `Accept-Language` header and changes only how names are
-*spelled*. It does **not** filter regional **availability** or vary **preview
-URLs** — anonymous Spotify resolves country from the request IP, and its
-pathfinder silently ignores a `market` variable. True market/availability
+*spelled*. It is **not** a country/market code — a bare `"US"` is meaningless as
+a language and is ignored — and it does **not** filter regional **availability**
+or vary **preview URLs**: anonymous Spotify resolves country from the request IP,
+and its pathfinder silently ignores a `market` variable. True market/availability
 filtering requires the authenticated Web API, which this library does not
-implement; for region-specific results, point the client's `proxy` at the
-target region.
+implement; for region-specific results, point the client's `proxy` at the target
+region. See the
+[localization guide](https://spotifyscraper.readthedocs.io/en/latest/guides/localization/).
 
 ## Features
 
@@ -164,14 +166,13 @@ Your cookie is sent only to Spotify and never logged. See the
 | **3.0** | The library: all entities, pagination, media downloads, browser fallback, docs |
 | **3.1** | Command-line interface |
 | **3.2** | Cookie-authenticated lyrics |
-| **3.4** | [Search](https://github.com/AliAkhtari78/SpotifyScraper/issues/129) across every entity type (`search()`) |
+| **3.4** | [Search](https://github.com/AliAkhtari78/SpotifyScraper/issues/129) across every entity type (`search()`) · display-language [localization](https://github.com/AliAkhtari78/SpotifyScraper/issues/130) (`locale`) |
 
 **Planned** — tracked in [milestones](https://github.com/AliAkhtari78/SpotifyScraper/milestones); 👍 or weigh in on the issues to help prioritize:
 
 | Version | Scope |
 |---------|-------|
 | **3.3** | Podcast [transcripts](https://github.com/AliAkhtari78/SpotifyScraper/issues/127) · first-class [auth & session persistence](https://github.com/AliAkhtari78/SpotifyScraper/issues/128) (browser-assisted login, no stored passwords) |
-| **3.4** | [market / region](https://github.com/AliAkhtari78/SpotifyScraper/issues/130) support |
 | **3.5** | Optional [response cache](https://github.com/AliAkhtari78/SpotifyScraper/issues/131) · [batch helpers](https://github.com/AliAkhtari78/SpotifyScraper/issues/132) with managed concurrency |
 
 Planned scope is subject to change.

--- a/docs/guides/localization.md
+++ b/docs/guides/localization.md
@@ -1,0 +1,59 @@
+# Localization
+
+Pass `locale` to control the **language** that Spotify uses for localized display
+names (artist names, titles transliterated into another script, and so on). It is
+a display-language preference and nothing more.
+
+```python
+from spotify_scraper import SpotifyClient
+
+# Per-client default — applies to every call:
+with SpotifyClient(locale="ja-JP") as client:
+    track = client.get_track("4uLU6hMCjMI75M1A2tKUQC")
+    print(track.artists[0].name)            # e.g. リック・アストリー
+
+    # Per-call override wins over the client default:
+    track = client.get_track("4uLU6hMCjMI75M1A2tKUQC", locale="de")
+```
+
+`locale` is accepted on the constructor and as a keyword on every entity getter
+and on `search()`. It is sent as the HTTP `Accept-Language` header on both the
+pathfinder and embed requests (including pagination). When omitted, behavior is
+byte-identical to before (the transport's default `Accept-Language: en`).
+
+## What `locale` accepts
+
+A **BCP-47 language tag**:
+
+- a bare primary language subtag (2–3 letters), normalized to lower-case —
+  `"de"`, `"ja"`, `"en"`, `"por"`;
+- or a language-region tag, returned unchanged — `"ja-JP"`, `"en-US"`, `"pt-BR"`,
+  `"zh-Hant-TW"`.
+
+Anything else raises `URLError` **before any network request**, at both
+construction and per call:
+
+```python
+SpotifyClient(locale="deutsch")    # URLError: not a valid language tag
+client.get_track(id, locale="x_y") # URLError
+```
+
+## What `locale` is *not*
+
+!!! warning "`locale` is a language, not a country/market"
+    `locale` is **not** an ISO-3166 country code. A bare country code like `"US"`
+    or `"GB"` is meaningless as an `Accept-Language` value and is silently ignored
+    by Spotify — it does **not** select a market.
+
+`locale` changes only how names are *spelled*; it does **not**:
+
+- filter regional **availability**, or
+- vary **preview URLs** or playability.
+
+On the anonymous extraction ladder this library uses, Spotify resolves the
+country from the request **IP**, and its pathfinder GraphQL silently discards a
+`market` variable — so there is deliberately **no** anonymous `market=` toggle
+that would appear to work while changing nothing. True market/availability
+filtering requires the authenticated Web API, which this library does not
+implement anonymously. For region-specific results, point the client's `proxy`
+at the target region instead.

--- a/docs/index.md
+++ b/docs/index.md
@@ -154,7 +154,7 @@ anti-ban resilience, the browser fallback — plus the command-line interface.
 | 3.0.0 | Core library. |
 | 3.1.0 | The command-line interface. |
 | 3.2.0 | Cookie-authenticated **lyrics** extraction. |
-| 3.4 | **Search** across every entity type (`search()`). |
+| 3.4 | **Search** across every entity type (`search()`) and display-language **localization** (`locale`). |
 
 ### Planned
 
@@ -164,7 +164,6 @@ Upcoming work is tracked in the GitHub
 | Version | Adds |
 |---|---|
 | 3.3 | Podcast [transcripts](https://github.com/AliAkhtari78/SpotifyScraper/issues/127) and first-class [authenticated sessions](https://github.com/AliAkhtari78/SpotifyScraper/issues/128) — browser-assisted login with a persistent cookie store (no stored passwords). |
-| 3.4 | [market / region](https://github.com/AliAkhtari78/SpotifyScraper/issues/130) support. |
 | 3.5 | Optional [response caching](https://github.com/AliAkhtari78/SpotifyScraper/issues/131) and [batch helpers](https://github.com/AliAkhtari78/SpotifyScraper/issues/132) with managed concurrency. |
 
 Scope is subject to change — 👍 the issues that matter most to you.
@@ -178,6 +177,11 @@ Scope is subject to change — 👍 the issues that matter most to you.
     `client.search(query, types=..., limit=...)` returns a typed
     `SearchResults` across every entity type. See the
     [Search guide](guides/search.md).
+
+!!! success "Localization has shipped"
+    Pass `locale` (a BCP-47 **language** tag like `"ja-JP"`) per client or per
+    call to localize display-name language. It is not a market/country toggle —
+    see the [Localization guide](guides/localization.md).
 
 !!! warning "Legal & terms of service"
     SpotifyScraper is intended for **personal, educational, and research use**.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
   - Guides:
     - Entities: guides/entities.md
     - Search: guides/search.md
+    - Localization: guides/localization.md
     - CLI: guides/cli.md
     - Lyrics & cookies: guides/lyrics-and-cookies.md
     - Async: guides/async.md

--- a/openspec/changes/add-market-region-parameter/.openspec.yaml
+++ b/openspec/changes/add-market-region-parameter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-14

--- a/openspec/changes/add-market-region-parameter/design.md
+++ b/openspec/changes/add-market-region-parameter/design.md
@@ -1,0 +1,87 @@
+# Design: add-market-region-parameter
+
+## The decision the live probe forced
+
+Issue #130 assumes a `market=` that "threads into the existing request builders
+and the `market=from_token` path." A decisive anonymous probe (2026-06-14)
+disproves the GraphQL-variable mechanism: on `getTrack`, the payload is
+byte-identical (hash `4751d64a...`) for `no_market = US = DE = JP =
+ZZ(invalid country) = from_token = qqq=X`. The bogus-`qqq` control proves
+persisted queries silently discard unknown variables, so `market` "not erroring"
+is meaningless — it is dropped. Same on `searchDesktop` and
+`queryArtistOverview`. Therefore a `market=` routed as a pathfinder variable
+would be a **no-op kwarg**, which the task explicitly forbids.
+
+The probe also identifies the one anonymous lever that *does* change responses:
+the **`Accept-Language` HTTP header**. `getTrack` with `Accept-Language: ja-JP`
+changed exactly the display names (transliterations) and nothing else — no
+availability, playability, or preview change. The pre-existing empty `locale`
+GraphQL variable (`pathfinder.py:48,53`) is independently confirmed inert.
+Anonymous country is IP-bound (no country in the embed `__NEXT_DATA__`;
+`/get_access_token` 403 and `/api/token` 400 anonymously), so true market control
+would need a region-pinned proxy — out of scope.
+
+**Design conclusion:** implement the proven-working capability (display-language
+localization) under an honest name, `locale=`, threaded as `Accept-Language`;
+deliver the requested ISO-3166 alpha-2 validator (`URLError` on bad code) as
+`urls.normalize_locale`; and explicitly scope out + document anonymous
+market/availability.
+
+## Mechanism: header, not variable
+
+`api/pathfinder.py` is untouched — no `market`/`locale` variable is injected, so
+every pathfinder URL stays byte-identical and all URL-shape tests stay green
+(this also keeps the hash table the sole concern of that module). Instead the
+resolved locale becomes a per-request header:
+
+- A tiny private `_lang_header(locale) -> {"Accept-Language": locale}` (or `{}`
+  when `None`) is merged after `pathfinder.auth_headers(token)` in
+  `_pathfinder_request`/`_search_request`, and applied to the embed GET in
+  `_fetch_next_data` so the tier-2 fallback localizes too.
+- `transport.get` already merges `{**self._headers, **(headers or {})}` with the
+  caller winning, so a per-request `Accept-Language` cleanly overrides the
+  transport default (`headers.py:34` = `Accept-Language: en`).
+
+## Validation home and shape
+
+`normalize_locale` lives in `urls.py` beside `parse` (the established home for
+input classifiers that raise `URLError`) and is exported for both clients. It is
+regex-only (no `pycountry`; the one-dependency rule forbids it): a bare
+`[A-Za-z]{2}` country code is upper-cased; a `[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*`
+language-region tag passes through; anything else raises `URLError`. It is
+`str -> str`, I/O-free, mypy --strict clean.
+
+## Threading (mirrors existing pagination-option layering)
+
+`locale` resolves once per public call
+(`effective = normalize_locale(locale) if locale is not None else self._locale`),
+exactly how `max_tracks`/`max_episodes` already layer per-call over a default,
+and is forwarded down the SAME private chain the pagination overrides use:
+
+- Entities: getter -> `_get_entity` -> `_fetch_union` -> `_pathfinder_request`;
+  plus `_paginate` and `_with_episodes` (which re-enter `_fetch_union`). The
+  paginating getters pass one `effective` into both the first fetch and the
+  follow-up pages so a single call uses one consistent locale on every page.
+- Search: `search` -> `_search_union` -> `_search_request`.
+- The `except TokenError: invalidate -> retry-once` blocks already forward
+  `overrides`; they forward `locale` the same way on the second attempt.
+
+Validation happens at exactly two boundaries (constructor + each call), both
+raising `URLError` before any I/O; the private layer receives only trusted,
+already-normalized values.
+
+## Why not parameterize lyrics
+
+`get_lyrics` is the authenticated cookie path; its `market=from_token`
+(`lyrics.py:11`) is a real Web-API market token that genuinely filters, but it is
+out of #130's anonymous scope and is left untouched to keep this change minimal
+and isolated.
+
+## Honesty in the public contract
+
+The spec, docstrings, and README state that anonymous `locale=` localizes
+display-name *language* only — not availability or preview URLs — and that the
+pathfinder `market` variable is inert. A `@pytest.mark.live` negative-scope test
+asserts two locales leave availability/playability unchanged, guarding the
+limitation from silent regression. This prevents the feature from being mis-sold
+as region/availability control it cannot deliver anonymously.

--- a/openspec/changes/add-market-region-parameter/proposal.md
+++ b/openspec/changes/add-market-region-parameter/proposal.md
@@ -1,0 +1,86 @@
+# Proposal: add-market-region-parameter
+
+> **Status: targets a v3.x point release.** Addresses issue #130
+> (market/region for localized metadata & availability). **A live probe forced an
+> honest scope:** Spotify's anonymous pathfinder silently DISCARDS a `market`
+> variable, so a `market=` kwarg routed as a GraphQL variable would be a no-op.
+> This proposal ships the lever the probe PROVED works — `Accept-Language`
+> (display-language localization) — as an optional, validated `locale=`
+> parameter, and explicitly scopes out (and documents) anonymous
+> availability/region filtering, which is not achievable without the
+> authenticated Web API.
+
+## Why
+
+Issue #130 asks for an optional `market=` (ISO-3166 country) at the client and/or
+per call, "Spotify varies availability, names, and preview URLs by market." A
+decisive live anonymous probe (2026-06-14) shows that, on the anonymous two-tier
+ladder this library uses, **only display-name *language* is controllable, and
+only via the `Accept-Language` HTTP header** — not availability, not preview
+URLs, not via any GraphQL variable:
+
+- The pathfinder `market` variable is **inert**: `getTrack` returns a
+  byte-identical payload for `no_market = US = DE = JP = ZZ(invalid) = from_token
+  = qqq=X(bogus)` (all HTTP 200). Persisted queries accept and discard unknown
+  variables; the bogus-`qqq` control proves "it doesn't error" means nothing.
+- `Accept-Language: ja-JP` **does** change the response — but every changed leaf
+  is a transliterated display name (Rick Astley -> リック・アストリー); zero
+  `playability`/`contentRating`/availability/preview change. Language lever, not
+  market lever.
+- The existing empty `locale` GraphQL variable (`pathfinder.py:48,53`) is a no-op
+  confirmed on `queryArtistOverview`; localization is header-driven.
+- Anonymous country is **IP-bound**: no country field is surfaced in the embed
+  `__NEXT_DATA__`, and the country-bearing endpoints are blocked anonymously
+  (`/get_access_token` -> 403, `/api/token` -> 400). Real `market=`/`from_token`
+  availability filtering lives only on the authenticated `api.spotify.com`, which
+  the anonymous ladder does not touch.
+
+Shipping a `market=` pathfinder variable would therefore be a silent no-op — the
+task explicitly forbids that. We instead ship the proven-working capability under
+an honest name and document the limitation.
+
+## What Changes
+
+- **`urls.py`** gains a pure `normalize_locale(value: str) -> str` validator
+  (regex-only, zero new deps) that accepts a bare ISO-3166 alpha-2 code
+  (upper-cased, e.g. `"de"` -> `"DE"`) or a full language-region tag
+  (`"ja-JP"`, `"en-US"`, passed through), and raises **`URLError`** on bad input
+  (`""`, `"USA"`, `"u1"`, `"123"`). This is the "market (ISO-3166 alpha-2,
+  validated -> URLError on bad code)" validator the task requires; what it sets
+  anonymously is the display language, not availability.
+- **Both clients** gain an optional, keyword-only `locale: str | None = None`:
+  a per-client default in `__init__` (validated once at construction; stored in a
+  new `_locale` slot) **and** a per-call override on every getter and `search`
+  (per-call wins). Resolution is
+  `urls.normalize_locale(locale) if locale is not None else self._locale`,
+  mirroring how `max_tracks`/`max_episodes` layer per-call over default.
+- **Threading is header-only.** The resolved locale flows down the private
+  request chain (`_get_entity`/`_fetch_union`/`_pathfinder_request`/`_paginate`/
+  `_with_episodes` for entities; `_search_union`/`_search_request` for search) and
+  is applied as a per-request **`Accept-Language`** header merged over the
+  transport default (`headers.py:34`, `Accept-Language: en`; caller wins in
+  `transport.get`). **No pathfinder variable and no `api/pathfinder.py` change** —
+  pathfinder URLs stay byte-identical, all existing URL-shape tests stay green.
+- **`get_lyrics` is unchanged** (authenticated path; its hardcoded
+  `market=from_token` in `lyrics.py:11` is out of scope).
+- **Docs + spec explicitly state the limitation:** anonymous `locale=` localizes
+  *display names* (language); it does **not** filter regional *availability* or
+  vary *preview URLs* — that requires the authenticated Web API, which this
+  library's anonymous ladder does not implement. The pathfinder `market` variable
+  is documented as inert so no future contributor models it as a variable.
+
+## Impact
+
+- New: `urls.normalize_locale` + its unit tests; `_locale` slot + `locale=`
+  kwargs on both clients (constructor, six getters, `search`); a per-request
+  `Accept-Language` header threaded through the private request layer; client
+  unit tests (per-call-overrides-per-client, URLError-before-HTTP at both
+  boundaries, header carried on the wire) sync + async; a `@pytest.mark.live`
+  smoke test asserting a localized display name differs between two locales.
+- Unchanged: `api/pathfinder.py` (no variable, hashes untouched), `errors.py`
+  (reuses `URLError`), every model and parser, `auth/`, `media/`, lyrics.
+- No new runtime dependency. No change to any existing method's behavior when
+  `locale` is omitted. `test_parity.py` keeps both facades' signatures identical.
+- **Honesty gate:** the spec and README/docs record that anonymous market
+  (availability/region) is NOT supported and why (IP-bound token + inert
+  variable), so the feature is not mis-sold.

--- a/openspec/changes/add-market-region-parameter/specs/locale/spec.md
+++ b/openspec/changes/add-market-region-parameter/specs/locale/spec.md
@@ -4,14 +4,15 @@
 
 ### Requirement: Optional display-language localization
 
-The clients SHALL accept an optional `locale` (an ISO-3166 alpha-2 code or a
-language-region tag such as `ja-JP`) at the client level
-(`SpotifyClient(locale=...)`) and as a per-call override on every entity getter
-and on `search`. When provided, the library SHALL send it as the
-`Accept-Language` HTTP header on the underlying requests so Spotify returns
-localized display names. When omitted, behavior SHALL be byte-identical to today
-(the transport's default `Accept-Language: en`). A per-call `locale` SHALL
-override the per-client default.
+The clients SHALL accept an optional `locale` — a BCP-47 **language** tag (a bare
+language subtag such as `de`, or a language-region tag such as `ja-JP`), not a
+country/market code — at the client level (`SpotifyClient(locale=...)`) and as a
+per-call override on every entity getter and on `search`. When provided, the
+library SHALL send it as the `Accept-Language` HTTP header on the underlying
+requests (including pagination requests) so Spotify returns localized display
+names. When omitted, behavior SHALL be byte-identical to today (the transport's
+default `Accept-Language: en`). A per-call `locale` SHALL override the per-client
+default.
 
 #### Scenario: Per-client default
 
@@ -32,25 +33,28 @@ override the per-client default.
 
 ### Requirement: Locale validation
 
-A `locale` SHALL be validated as either an ISO-3166 alpha-2 country code
-(case-insensitive, normalized to upper-case) or a language-region tag. Invalid
-input SHALL raise `URLError` before any network request, at both client
-construction (per-client default) and per call (override).
+A `locale` SHALL be validated as a BCP-47 language tag: either a bare primary
+language subtag (2-3 letters, case-insensitive, normalized to **lower-case**) or
+a language-region tag (returned unchanged). Invalid input SHALL raise `URLError`
+before any network request, at both client construction (per-client default) and
+per call (override). A bare country code is NOT special-cased: it is either a
+syntactically-valid language subtag (sent verbatim as an ineffective
+`Accept-Language`) or invalid — it never selects a market.
 
-#### Scenario: Bare country code normalized
+#### Scenario: Bare language subtag normalized
 
-- **WHEN** `locale="de"` is supplied
-- **THEN** it is accepted and used as `DE`
+- **WHEN** `locale="DE"` (or `"por"`) is supplied
+- **THEN** it is accepted and used lower-cased as `de` (resp. `por`)
 
-#### Scenario: Language tag accepted
+#### Scenario: Language-region tag accepted
 
 - **WHEN** `locale="en-US"` is supplied
 - **THEN** it is accepted unchanged
 
-#### Scenario: Invalid code rejected before I/O
+#### Scenario: Invalid tag rejected before I/O
 
-- **WHEN** `locale="USA"` (or `""`, `"u1"`, `"123"`) is supplied at construction
-  or per call
+- **WHEN** `locale="deutsch"` (or `""`, `"u1"`, `"123"`, `"x_y"`) is supplied at
+  construction or per call
 - **THEN** `URLError` is raised and no HTTP request is issued
 
 ### Requirement: Anonymous market/availability is not supported

--- a/openspec/changes/add-market-region-parameter/specs/locale/spec.md
+++ b/openspec/changes/add-market-region-parameter/specs/locale/spec.md
@@ -1,0 +1,77 @@
+# locale
+
+## ADDED Requirements
+
+### Requirement: Optional display-language localization
+
+The clients SHALL accept an optional `locale` (an ISO-3166 alpha-2 code or a
+language-region tag such as `ja-JP`) at the client level
+(`SpotifyClient(locale=...)`) and as a per-call override on every entity getter
+and on `search`. When provided, the library SHALL send it as the
+`Accept-Language` HTTP header on the underlying requests so Spotify returns
+localized display names. When omitted, behavior SHALL be byte-identical to today
+(the transport's default `Accept-Language: en`). A per-call `locale` SHALL
+override the per-client default.
+
+#### Scenario: Per-client default
+
+- **WHEN** a client is built with `SpotifyClient(locale="ja-JP")` and `get_track`
+  is called without `locale`
+- **THEN** the pathfinder (and embed) requests carry `Accept-Language: ja-JP`
+
+#### Scenario: Per-call override wins
+
+- **WHEN** a client built with `locale="de-DE"` calls `get_track(url, locale="ja-JP")`
+- **THEN** the requests carry `Accept-Language: ja-JP`, not `de-DE`
+
+#### Scenario: Omitted locale is a no-op
+
+- **WHEN** neither the client nor the call sets `locale`
+- **THEN** no per-request `Accept-Language` override is added and the request
+  headers are identical to the pre-change behavior
+
+### Requirement: Locale validation
+
+A `locale` SHALL be validated as either an ISO-3166 alpha-2 country code
+(case-insensitive, normalized to upper-case) or a language-region tag. Invalid
+input SHALL raise `URLError` before any network request, at both client
+construction (per-client default) and per call (override).
+
+#### Scenario: Bare country code normalized
+
+- **WHEN** `locale="de"` is supplied
+- **THEN** it is accepted and used as `DE`
+
+#### Scenario: Language tag accepted
+
+- **WHEN** `locale="en-US"` is supplied
+- **THEN** it is accepted unchanged
+
+#### Scenario: Invalid code rejected before I/O
+
+- **WHEN** `locale="USA"` (or `""`, `"u1"`, `"123"`) is supplied at construction
+  or per call
+- **THEN** `URLError` is raised and no HTTP request is issued
+
+### Requirement: Anonymous market/availability is not supported
+
+The library SHALL NOT expose a `market=`/availability parameter on the anonymous
+ladder and SHALL NOT model `market` as a pathfinder GraphQL variable, because
+Spotify's anonymous pathfinder silently discards such a variable and resolves
+country from the request IP. Documentation SHALL state that `locale` localizes
+display-name *language* only and that regional *availability*/preview filtering
+requires the authenticated Web API, which this library does not implement
+anonymously.
+
+#### Scenario: No silent no-op kwarg
+
+- **WHEN** a caller wants regional availability filtering
+- **THEN** the public API offers no anonymous `market=` toggle that would appear
+  to work while changing nothing; the documented path is the authenticated Web
+  API (out of scope)
+
+#### Scenario: Locale does not change availability
+
+- **WHEN** the same entity is fetched with two different `locale` values
+- **THEN** only localized display names may differ; availability/playability
+  fields are unchanged

--- a/openspec/changes/add-market-region-parameter/tasks.md
+++ b/openspec/changes/add-market-region-parameter/tasks.md
@@ -102,3 +102,18 @@
 - [x] 7.2 `@pytest.mark.live` negative-scope guard: assert that two locales return
       the SAME `playability`/availability-shaped fields (documents that locale is
       language-only, not market) — keeps the limitation honest under `make live`.
+
+## 8. Review fixes (locale-vs-market decision: language-only / honest)
+
+- [x] 8.1 `normalize_locale` reframed as a BCP-47 **language** tag: accepts bare
+      language subtags (2-3 letters, lower-cased) and language-region tags; drops
+      the "ISO-3166 alpha-2 country code"/upper-case/`US` framing. Now accepts
+      bare 3-letter language codes (e.g. `por`); error message says "language tag".
+- [x] 8.2 Client `__init__` docstrings reframed to "BCP-47 language tag" (no
+      "ISO-3166 country code"); README "Localized display names" reframed.
+- [x] 8.3 Tests: bare subtag lower-cased on the wire (sync + async); bare 3-letter
+      language accepted; multi-page pagination carries `Accept-Language` on page 2;
+      `search` invalid-locale async parity; updated accept/reject vectors.
+- [x] 8.4 Docs: new `guides/localization.md` (language-only, not market) + nav;
+      index roadmap (3.4 localization shipped) + success admonition; CHANGELOG;
+      spec reframed to language-only (lower-case normalization).

--- a/openspec/changes/add-market-region-parameter/tasks.md
+++ b/openspec/changes/add-market-region-parameter/tasks.md
@@ -1,0 +1,104 @@
+# Tasks: add-market-region-parameter
+
+## 0. Live verification (BLOCKS the mechanism choice) — DONE
+
+- [x] 0.1 Anonymous bearer probe (same bootstrap as get_track) confirms the
+      pathfinder `market` variable is INERT: getTrack payload byte-identical for
+      no_market = US = DE = JP = ZZ(invalid) = from_token = qqq=X(bogus control),
+      all HTTP 200. searchDesktop/queryArtistOverview show the same (only random
+      requestIds/CDN-host noise differs). => no GraphQL `market` variable.
+- [x] 0.2 `Accept-Language: ja-JP` on getTrack changes ONLY display names
+      (Rick Astley -> リック・アストリー); no playability/contentRating/availability/
+      preview change. => Accept-Language is the language lever; not a market lever.
+- [x] 0.3 Empty `locale` GraphQL variable is a no-op (queryArtistOverview
+      locale in {"",en,ja,ja_JP,de} all "Rick Astley"; only the header changes it).
+- [x] 0.4 No country surfaced in embed __NEXT_DATA__; /get_access_token=403,
+      /api/token=400 anonymously => country is IP-bound, not settable. Conclusion:
+      ship Accept-Language-backed `locale=`; scope out anonymous market/availability.
+
+## 1. Validator (urls.py, raises URLError)
+
+- [x] 1.1 In `src/spotify_scraper/urls.py` add `normalize_locale(value: str) -> str`:
+      strip; accept a bare ISO-3166 alpha-2 (`[A-Za-z]{2}`) -> return upper-cased,
+      OR a language-region tag (`[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*`) -> return as-is;
+      else raise `URLError("Invalid locale {value!r}: expected an ISO-3166 alpha-2
+      code (e.g. 'US') or a language tag (e.g. 'ja-JP').")`. Regex-only, no new dep.
+- [x] 1.2 Add a module `_LOCALE_RE`/`_MARKET_RE` constant; keep the function
+      I/O-free and `str -> str` (mypy --strict clean). Export-friendly (no `_`).
+
+## 2. Per-client default (constructors)
+
+- [x] 2.1 Add `"_locale"` to `__slots__` in both `_sync/client.py` and
+      `_async/client.py`.
+- [x] 2.2 Add keyword-only `locale: str | None = None` to both `__init__`
+      signatures + docstrings. Store
+      `self._locale = urls.normalize_locale(locale) if locale is not None else None`
+      (raises URLError at construction for a bad default — fail fast).
+
+## 3. Per-call override (getters + search)
+
+- [x] 3.1 Add keyword-only `locale: str | None = None` to `get_track`,
+      `get_album`, `get_artist`, `get_playlist`, `get_episode`, `get_show`,
+      `search` on BOTH clients (identical signatures — test_parity.py enforces).
+      Document in each docstring that it localizes display-name LANGUAGE only.
+- [x] 3.2 In each method resolve once, before any I/O:
+      `effective = urls.normalize_locale(locale) if locale is not None else self._locale`
+      (per-call wins; invalid per-call code raises URLError before any request).
+
+## 4. Thread the resolved locale to a per-request Accept-Language header
+
+- [x] 4.1 Add `locale: str | None = None` param to the entity chain:
+      `_get_entity`, `_fetch_union`, `_pathfinder_request`, `_paginate`,
+      `_with_episodes` (both clients). Forward `effective` from each getter; the
+      paginating getters (album/playlist/show) pass the SAME `effective` to both
+      `_get_entity` and the follow-up `_paginate`/`_with_episodes` so every page
+      uses one locale.
+- [x] 4.2 Add `locale` param to the search chain: `_search_union`,
+      `_search_request` (both clients); forward `effective` from `search`.
+- [x] 4.3 In `_pathfinder_request` and `_search_request`, build the request
+      headers as `{**pathfinder.auth_headers(token), **_lang_header(locale)}`
+      where `_lang_header(locale)` returns `{"Accept-Language": locale}` when
+      `locale` is not None else `{}`. (Caller-wins merge in `transport.get`
+      overrides the default `Accept-Language: en`.) Also apply the same header to
+      `_fetch_next_data` (the embed GET) so the tier-2 fallback localizes too.
+- [x] 4.4 The TokenError retry blocks in `_fetch_union`/`_search_union` already
+      forward `overrides`; forward `locale` identically on the second attempt.
+- [x] 4.5 Do NOT touch `api/pathfinder.py` (no variable). Confirm
+      `build_url`/`build_search_url` outputs are byte-identical to before.
+
+## 5. Tests (hermetic by default)
+
+- [x] 5.1 `tests/unit/test_urls.py`: `normalize_locale` happy paths
+      (`"de"`->`"DE"`, `"GB"`->`"GB"`, `"ja-JP"`->`"ja-JP"`, `"en-US"`->`"en-US"`)
+      and URLError on `""`, `"USA"`, `"u1"`, `"123"`, `"x_y"`.
+- [x] 5.2 `tests/unit/test_client_locale.py` (respx, sync+async): with a fake
+      transport capturing headers, assert the pathfinder (and embed) request
+      carries `Accept-Language: <resolved>`; assert per-call overrides per-client;
+      assert a bad `locale` raises URLError with NO HTTP issued at BOTH
+      construction and call time; assert that omitting `locale` sends no
+      per-request Accept-Language override (default `en` only); assert `search`
+      carries the header too; parity.
+- [x] 5.3 `tests/unit/test_parity.py` already enforces signature parity — confirm
+      both facades gained identical `locale` kwargs (constructor + all 7 methods).
+- [x] 5.4 `make type` (mypy --strict), `make lint`, `make test`, `make cov`
+      (>=85%) all green.
+
+## 6. Docs + honest scope
+
+- [x] 6.1 In the `locale` spec (Requirement scenarios) and docstrings, state
+      plainly: anonymous `locale=` localizes display-name LANGUAGE; it does NOT
+      filter regional availability or vary preview URLs. The pathfinder `market`
+      variable is inert (IP-bound token). True market/availability requires the
+      authenticated Web API (out of scope).
+- [x] 6.2 README/docs: short note + example
+      `SpotifyClient(locale="ja-JP")` / `get_track(url, locale="de-DE")`.
+
+## 7. Live verification (excluded from default run)
+
+- [x] 7.1 `@pytest.mark.live` (`tests/live/`): `get_track(<known track>,
+      locale="ja")` vs the default — assert at least one artist/display name
+      differs (the proven-working effect) and the localized name is non-ASCII.
+      Assert it runs with NO cookie.
+- [x] 7.2 `@pytest.mark.live` negative-scope guard: assert that two locales return
+      the SAME `playability`/availability-shaped fields (documents that locale is
+      language-only, not market) — keeps the limitation honest under `make live`.

--- a/src/spotify_scraper/_async/client.py
+++ b/src/spotify_scraper/_async/client.py
@@ -96,13 +96,15 @@ class AsyncSpotifyClient:
                 stored now, consumed by the lyrics extraction change.
             host_rate_limits: Optional per-host rate overrides for the default
                 transport (e.g. to throttle ``api-partner.spotify.com``).
-            locale: Default display-language for localized names, an ISO-3166
-                alpha-2 code (e.g. ``"DE"``) or a language tag (e.g.
-                ``"ja-JP"``), sent as the ``Accept-Language`` header. Localizes
-                display-name LANGUAGE only; it does NOT filter regional
-                availability or vary preview URLs (those require the
-                authenticated Web API). A per-call ``locale`` overrides it.
-                Raises :class:`~spotify_scraper.errors.URLError` if invalid.
+            locale: Default display-language for localized names, a BCP-47
+                language tag — a bare language subtag (e.g. ``"de"``, ``"ja"``)
+                or a language-region tag (e.g. ``"ja-JP"``) — sent as the
+                ``Accept-Language`` header. Localizes display-name LANGUAGE only;
+                a bare country code like ``"US"`` is not a language and is
+                ignored. It does NOT filter regional availability or vary preview
+                URLs (those require the authenticated Web API). A per-call
+                ``locale`` overrides it. Raises
+                :class:`~spotify_scraper.errors.URLError` if invalid.
         """
         if transport is None:
             self._transport: AsyncTransport = AsyncHttpxTransport(

--- a/src/spotify_scraper/_async/client.py
+++ b/src/spotify_scraper/_async/client.py
@@ -61,6 +61,7 @@ class AsyncSpotifyClient:
     __slots__ = (
         "_closed",
         "_cookies",
+        "_locale",
         "_lyrics_tokens",
         "_owns_transport",
         "_tokens",
@@ -78,6 +79,7 @@ class AsyncSpotifyClient:
         transport: AsyncTransport | None = None,
         cookies: str | Path | Mapping[str, str] | None = None,
         host_rate_limits: Mapping[str, RateLimit] | None = None,
+        locale: str | None = None,
     ) -> None:
         """Initialize the client.
 
@@ -94,6 +96,13 @@ class AsyncSpotifyClient:
                 stored now, consumed by the lyrics extraction change.
             host_rate_limits: Optional per-host rate overrides for the default
                 transport (e.g. to throttle ``api-partner.spotify.com``).
+            locale: Default display-language for localized names, an ISO-3166
+                alpha-2 code (e.g. ``"DE"``) or a language tag (e.g.
+                ``"ja-JP"``), sent as the ``Accept-Language`` header. Localizes
+                display-name LANGUAGE only; it does NOT filter regional
+                availability or vary preview URLs (those require the
+                authenticated Web API). A per-call ``locale`` overrides it.
+                Raises :class:`~spotify_scraper.errors.URLError` if invalid.
         """
         if transport is None:
             self._transport: AsyncTransport = AsyncHttpxTransport(
@@ -109,11 +118,15 @@ class AsyncSpotifyClient:
             self._transport = transport
             self._owns_transport = False
         self._cookies = cookies
+        self._locale = urls.normalize_locale(locale) if locale is not None else None
         self._tokens = AsyncAnonymousTokenProvider(self._transport)
         self._lyrics_tokens: AsyncCookieTokenProvider | None = None
         self._closed = False
 
-    async def get_track(self, value: str) -> Track:
+    def _effective_locale(self, locale: str | None) -> str | None:
+        return urls.normalize_locale(locale) if locale is not None else self._locale
+
+    async def get_track(self, value: str, *, locale: str | None = None) -> Track:
         """Fetch a track by URL, URI, or bare ID.
 
         The embed page is fetched first: it supplies the tier-2 fallback
@@ -123,15 +136,19 @@ class AsyncSpotifyClient:
 
         Args:
             value: A Spotify track URL, URI, or 22-character ID.
+            locale: Per-call display-language override (``Accept-Language``);
+                localizes display-name LANGUAGE only, not availability/preview.
 
         Returns:
             The richest available :class:`Track`.
 
         Raises:
+            URLError: If ``locale`` is invalid.
             NotFoundError: If the track does not exist.
             SpotifyScraperError: If the client is closed.
         """
         _, entity_id = self._resolve(value, "track")
+        effective = self._effective_locale(locale)
         model, _, _, _ = await self._get_entity(
             "track",
             entity_id,
@@ -139,30 +156,36 @@ class AsyncSpotifyClient:
             parse_entities.parse_track_gql,
             parse_entities.parse_track_embed,
             merge=parse_entities._merge_tracks,
+            locale=effective,
         )
         return model
 
-    async def get_album(self, value: str) -> Album:
+    async def get_album(self, value: str, *, locale: str | None = None) -> Album:
         """Fetch an album by URL, URI, or bare ID, paginating its tracks.
 
         Args:
             value: A Spotify album URL, URI, or 22-character ID.
+            locale: Per-call display-language override (``Accept-Language``);
+                localizes display-name LANGUAGE only, not availability/preview.
 
         Returns:
             The richest available :class:`Album` with as many tracks as the
             pathfinder pages provided (all of them by default).
 
         Raises:
+            URLError: If ``locale`` is invalid.
             NotFoundError: If the album does not exist.
             SpotifyScraperError: If the client is closed.
         """
         _, entity_id = self._resolve(value, "album")
+        effective = self._effective_locale(locale)
         album, session, tier1, union = await self._get_entity(
             "album",
             entity_id,
             "albumUnion",
             parse_entities.parse_album_gql,
             parse_entities.parse_album_embed,
+            locale=effective,
         )
         if not tier1 or union is None:
             return album
@@ -178,55 +201,68 @@ class AsyncSpotifyClient:
             page_size=_ALBUM_PAGE,
             max_items=None,
             parse_page=parse_entities.parse_album_tracks_page,
+            locale=effective,
         )
         if not tracks:
             return album
         return _with_album_tracks(album, (*album.tracks, *tracks))
 
-    async def get_artist(self, value: str) -> Artist:
+    async def get_artist(self, value: str, *, locale: str | None = None) -> Artist:
         """Fetch an artist by URL, URI, or bare ID.
 
         Args:
             value: A Spotify artist URL, URI, or 22-character ID.
+            locale: Per-call display-language override (``Accept-Language``);
+                localizes display-name LANGUAGE only, not availability/preview.
 
         Returns:
             The richest available :class:`Artist`.
 
         Raises:
+            URLError: If ``locale`` is invalid.
             NotFoundError: If the artist does not exist.
             SpotifyScraperError: If the client is closed.
         """
         _, entity_id = self._resolve(value, "artist")
+        effective = self._effective_locale(locale)
         artist, _, _, _ = await self._get_entity(
             "artist",
             entity_id,
             "artistUnion",
             parse_entities.parse_artist_gql,
             parse_entities.parse_artist_embed,
+            locale=effective,
         )
         return artist
 
-    async def get_playlist(self, value: str, *, max_tracks: int | None = 100) -> Playlist:
+    async def get_playlist(
+        self, value: str, *, max_tracks: int | None = 100, locale: str | None = None
+    ) -> Playlist:
         """Fetch a playlist by URL, URI, or bare ID, paginating its tracks.
 
         Args:
             value: A Spotify playlist URL, URI, or 22-character ID.
             max_tracks: Upper bound on tracks to collect; ``None`` fetches all.
+            locale: Per-call display-language override (``Accept-Language``);
+                localizes display-name LANGUAGE only, not availability/preview.
 
         Returns:
             The richest available :class:`Playlist`.
 
         Raises:
+            URLError: If ``locale`` is invalid.
             NotFoundError: If the playlist does not exist.
             SpotifyScraperError: If the client is closed.
         """
         _, entity_id = self._resolve(value, "playlist")
+        effective = self._effective_locale(locale)
         playlist, session, tier1, union = await self._get_entity(
             "playlist",
             entity_id,
             "playlistV2",
             lambda union: parse_entities.parse_playlist_gql(union, max_tracks=max_tracks),
             parse_entities.parse_playlist_embed,
+            locale=effective,
         )
         if not tier1 or union is None:
             return playlist
@@ -242,61 +278,74 @@ class AsyncSpotifyClient:
             page_size=_PLAYLIST_PAGE,
             max_items=max_tracks,
             parse_page=parse_entities.parse_playlist_tracks_page,
+            locale=effective,
         )
         if not tracks:
             return playlist
         return _with_playlist_tracks(playlist, (*playlist.tracks, *tracks))
 
-    async def get_episode(self, value: str) -> Episode:
+    async def get_episode(self, value: str, *, locale: str | None = None) -> Episode:
         """Fetch a podcast episode by URL, URI, or bare ID.
 
         Args:
             value: A Spotify episode URL, URI, or 22-character ID.
+            locale: Per-call display-language override (``Accept-Language``);
+                localizes display-name LANGUAGE only, not availability/preview.
 
         Returns:
             The richest available :class:`Episode`.
 
         Raises:
+            URLError: If ``locale`` is invalid.
             NotFoundError: If the episode does not exist.
             SpotifyScraperError: If the client is closed.
         """
         _, entity_id = self._resolve(value, "episode")
+        effective = self._effective_locale(locale)
         episode, _, _, _ = await self._get_entity(
             "episode",
             entity_id,
             "episodeUnionV2",
             parse_entities.parse_episode_gql,
             parse_entities.parse_episode_embed,
+            locale=effective,
         )
         return episode
 
-    async def get_show(self, value: str, *, max_episodes: int | None = 50) -> Show:
+    async def get_show(
+        self, value: str, *, max_episodes: int | None = 50, locale: str | None = None
+    ) -> Show:
         """Fetch a podcast show by URL, URI, or bare ID, listing its episodes.
 
         Args:
             value: A Spotify show URL, URI, or 22-character ID.
             max_episodes: Upper bound on episodes to collect; ``None`` fetches
                 all of them.
+            locale: Per-call display-language override (``Accept-Language``);
+                localizes display-name LANGUAGE only, not availability/preview.
 
         Returns:
             The richest available :class:`Show`, with ``total_episodes`` and a
             paginated ``episodes`` listing when tier 1 succeeds.
 
         Raises:
+            URLError: If ``locale`` is invalid.
             NotFoundError: If the show does not exist.
             SpotifyScraperError: If the client is closed.
         """
         _, entity_id = self._resolve(value, "show")
+        effective = self._effective_locale(locale)
         show, session, tier1, _ = await self._get_entity(
             "show",
             entity_id,
             "podcastUnionV2",
             parse_entities.parse_show_gql,
             parse_entities.parse_show_embed,
+            locale=effective,
         )
         if not tier1:
             return show
-        return await self._with_episodes(show, entity_id, session, max_episodes)
+        return await self._with_episodes(show, entity_id, session, max_episodes, locale=effective)
 
     async def get_lyrics(self, value: str) -> Lyrics:
         """Fetch a track's lyrics using the cookie-derived web-player token.
@@ -332,6 +381,7 @@ class AsyncSpotifyClient:
         *,
         types: Sequence[str] = _SEARCH_TYPES,
         limit: int = 20,
+        locale: str | None = None,
     ) -> SearchResults:
         """Search Spotify for tracks, albums, artists, playlists, shows, episodes.
 
@@ -346,18 +396,22 @@ class AsyncSpotifyClient:
                 ``"track"``, ``"album"``, ``"artist"``, ``"playlist"``,
                 ``"show"``, and ``"episode"``.
             limit: Maximum hits per section requested from Spotify.
+            locale: Per-call display-language override (``Accept-Language``);
+                localizes display-name LANGUAGE only, not availability/preview.
 
         Returns:
             A :class:`SearchResults` whose tuples for the requested ``types`` are
             populated; unrequested types stay empty.
 
         Raises:
-            URLError: If ``types`` contains an unrecognized entity type.
+            URLError: If ``types`` contains an unrecognized entity type, or
+                ``locale`` is invalid.
             SpotifyScraperError: If the client is closed.
         """
         self._ensure_open()
         wanted = _validate_search_types(types)
-        union = await self._search_union(query, limit)
+        effective = self._effective_locale(locale)
+        union = await self._search_union(query, limit, locale=effective)
         results = parse_entities.parse_search_results(union, query=query)
         return _filter_search_results(results, wanted)
 
@@ -451,7 +505,13 @@ class AsyncSpotifyClient:
         )
 
     async def _with_episodes(
-        self, show: Show, entity_id: str, session: EmbedSession, max_episodes: int | None
+        self,
+        show: Show,
+        entity_id: str,
+        session: EmbedSession,
+        max_episodes: int | None,
+        *,
+        locale: str | None = None,
     ) -> Show:
         first_limit = (
             _SHOW_EPISODES_PAGE if max_episodes is None else min(max_episodes, _SHOW_EPISODES_PAGE)
@@ -463,6 +523,7 @@ class AsyncSpotifyClient:
                 "podcastUnionV2",
                 session,
                 overrides={"offset": 0, "limit": first_limit},
+                locale=locale,
             )
         except (ParsingError, SpotifyScraperError) as exc:
             _LOGGER.warning("Show episode listing for %s failed: %s", entity_id, exc)
@@ -482,6 +543,7 @@ class AsyncSpotifyClient:
                 page_size=_SHOW_EPISODES_PAGE,
                 max_items=max_episodes,
                 parse_page=parse_entities.parse_show_episodes_page,
+                locale=locale,
             )
         )
         if max_episodes is not None:
@@ -524,6 +586,7 @@ class AsyncSpotifyClient:
         parse_embed_fn: Callable[[Mapping[str, Any]], _T],
         *,
         merge: Callable[[_T, _T], _T] | None = None,
+        locale: str | None = None,
     ) -> tuple[_T, EmbedSession, bool, Mapping[str, Any] | None]:
         """Run the embed-first two-tier ladder for one entity.
 
@@ -532,12 +595,12 @@ class AsyncSpotifyClient:
         the raw tier-1 union (so paginating callers can count raw items) or
         ``None`` when degraded.
         """
-        next_data = await self._fetch_next_data(kind, entity_id)
+        next_data = await self._fetch_next_data(kind, entity_id, locale=locale)
         embed_model = parse_embed_fn(parse_embed.get_entity(next_data))
         session = parse_embed.get_session(next_data)
 
         try:
-            union = await self._fetch_union(kind, entity_id, union_key, session)
+            union = await self._fetch_union(kind, entity_id, union_key, session, locale=locale)
             gql_model = parse_gql(union)
         except (ParsingError, NetworkError) as exc:
             _LOGGER.warning("Tier-1 %s fetch degraded to embed page: %s", kind, exc)
@@ -560,6 +623,7 @@ class AsyncSpotifyClient:
         page_size: int,
         max_items: int | None,
         parse_page: Callable[[Mapping[str, Any]], tuple[_T, ...]],
+        locale: str | None = None,
     ) -> tuple[_T, ...]:
         """Fetch follow-up pages after the first tier-1 page.
 
@@ -583,6 +647,7 @@ class AsyncSpotifyClient:
                     union_key,
                     session,
                     overrides={"offset": offset, "limit": page_size},
+                    locale=locale,
                 )
                 page = parse_page(union)
             except (ParsingError, SpotifyScraperError) as exc:
@@ -597,8 +662,13 @@ class AsyncSpotifyClient:
             return tuple(extra[: max(0, max_items - filtered_have)])
         return tuple(extra)
 
-    async def _fetch_next_data(self, kind: str, entity_id: str) -> dict[str, Any]:
-        response: Response = await self._transport.get(urls.embed_url(kind, entity_id))  # type: ignore[arg-type]
+    async def _fetch_next_data(
+        self, kind: str, entity_id: str, *, locale: str | None = None
+    ) -> dict[str, Any]:
+        response: Response = await self._transport.get(
+            urls.embed_url(kind, entity_id),  # type: ignore[arg-type]
+            headers=_lang_header(locale),
+        )
         return parse_embed.extract_next_data(response.text)
 
     async def _fetch_union(
@@ -609,13 +679,16 @@ class AsyncSpotifyClient:
         session: EmbedSession,
         *,
         overrides: Mapping[str, Any] | None = None,
+        locale: str | None = None,
     ) -> Mapping[str, Any]:
         try:
-            data = await self._pathfinder_request(kind, entity_id, session.access_token, overrides)
+            data = await self._pathfinder_request(
+                kind, entity_id, session.access_token, overrides, locale
+            )
         except TokenError:
             self._tokens.invalidate()
             data = await self._pathfinder_request(
-                kind, entity_id, await self._tokens.token(), overrides
+                kind, entity_id, await self._tokens.token(), overrides, locale
             )
         union = data.get(union_key)
         if not isinstance(union, Mapping):
@@ -631,19 +704,23 @@ class AsyncSpotifyClient:
         entity_id: str,
         token: str,
         overrides: Mapping[str, Any] | None,
+        locale: str | None = None,
     ) -> dict[str, Any]:
         url = pathfinder.build_url(kind, entity_id, variable_overrides=overrides)
-        response = await self._transport.get(url, headers=pathfinder.auth_headers(token))
+        headers = {**pathfinder.auth_headers(token), **_lang_header(locale)}
+        response = await self._transport.get(url, headers=headers)
         body = _safe_json(response)
         return pathfinder.classify_response(response.status_code, body)
 
-    async def _search_union(self, query: str, limit: int) -> Mapping[str, Any]:
+    async def _search_union(
+        self, query: str, limit: int, *, locale: str | None = None
+    ) -> Mapping[str, Any]:
         overrides = {"limit": limit}
         try:
-            data = await self._search_request(query, await self._tokens.token(), overrides)
+            data = await self._search_request(query, await self._tokens.token(), overrides, locale)
         except TokenError:
             self._tokens.invalidate()
-            data = await self._search_request(query, await self._tokens.token(), overrides)
+            data = await self._search_request(query, await self._tokens.token(), overrides, locale)
         union = data.get("searchV2")
         if not isinstance(union, Mapping):
             raise ParsingError(
@@ -657,11 +734,22 @@ class AsyncSpotifyClient:
         query: str,
         token: str,
         overrides: Mapping[str, Any] | None,
+        locale: str | None = None,
     ) -> dict[str, Any]:
         url = pathfinder.build_search_url(query, variable_overrides=overrides)
-        response = await self._transport.get(url, headers=pathfinder.auth_headers(token))
+        headers = {**pathfinder.auth_headers(token), **_lang_header(locale)}
+        response = await self._transport.get(url, headers=headers)
         body = _safe_json(response)
         return pathfinder.classify_response(response.status_code, body)
+
+
+def _lang_header(locale: str | None) -> dict[str, str]:
+    """Return a per-request ``Accept-Language`` override, or empty when unset.
+
+    The override wins over the transport default (``Accept-Language: en``) in
+    ``transport.get``, localizing display-name LANGUAGE only.
+    """
+    return {"Accept-Language": locale} if locale is not None else {}
 
 
 def _validate_search_types(types: Sequence[str]) -> frozenset[str]:

--- a/src/spotify_scraper/_sync/client.py
+++ b/src/spotify_scraper/_sync/client.py
@@ -97,13 +97,15 @@ class SpotifyClient:
                 stored now, consumed by the lyrics extraction change.
             host_rate_limits: Optional per-host rate overrides for the default
                 transport (e.g. to throttle ``api-partner.spotify.com``).
-            locale: Default display-language for localized names, an ISO-3166
-                alpha-2 code (e.g. ``"DE"``) or a language tag (e.g.
-                ``"ja-JP"``), sent as the ``Accept-Language`` header. Localizes
-                display-name LANGUAGE only; it does NOT filter regional
-                availability or vary preview URLs (those require the
-                authenticated Web API). A per-call ``locale`` overrides it.
-                Raises :class:`~spotify_scraper.errors.URLError` if invalid.
+            locale: Default display-language for localized names, a BCP-47
+                language tag — a bare language subtag (e.g. ``"de"``, ``"ja"``)
+                or a language-region tag (e.g. ``"ja-JP"``) — sent as the
+                ``Accept-Language`` header. Localizes display-name LANGUAGE only;
+                a bare country code like ``"US"`` is not a language and is
+                ignored. It does NOT filter regional availability or vary preview
+                URLs (those require the authenticated Web API). A per-call
+                ``locale`` overrides it. Raises
+                :class:`~spotify_scraper.errors.URLError` if invalid.
         """
         if transport is None:
             self._transport: Transport = HttpxTransport(

--- a/src/spotify_scraper/_sync/client.py
+++ b/src/spotify_scraper/_sync/client.py
@@ -62,6 +62,7 @@ class SpotifyClient:
     __slots__ = (
         "_closed",
         "_cookies",
+        "_locale",
         "_lyrics_tokens",
         "_owns_transport",
         "_tokens",
@@ -79,6 +80,7 @@ class SpotifyClient:
         transport: Transport | None = None,
         cookies: str | Path | Mapping[str, str] | None = None,
         host_rate_limits: Mapping[str, RateLimit] | None = None,
+        locale: str | None = None,
     ) -> None:
         """Initialize the client.
 
@@ -95,6 +97,13 @@ class SpotifyClient:
                 stored now, consumed by the lyrics extraction change.
             host_rate_limits: Optional per-host rate overrides for the default
                 transport (e.g. to throttle ``api-partner.spotify.com``).
+            locale: Default display-language for localized names, an ISO-3166
+                alpha-2 code (e.g. ``"DE"``) or a language tag (e.g.
+                ``"ja-JP"``), sent as the ``Accept-Language`` header. Localizes
+                display-name LANGUAGE only; it does NOT filter regional
+                availability or vary preview URLs (those require the
+                authenticated Web API). A per-call ``locale`` overrides it.
+                Raises :class:`~spotify_scraper.errors.URLError` if invalid.
         """
         if transport is None:
             self._transport: Transport = HttpxTransport(
@@ -110,11 +119,15 @@ class SpotifyClient:
             self._transport = transport
             self._owns_transport = False
         self._cookies = cookies
+        self._locale = urls.normalize_locale(locale) if locale is not None else None
         self._tokens = AnonymousTokenProvider(self._transport)
         self._lyrics_tokens: CookieTokenProvider | None = None
         self._closed = False
 
-    def get_track(self, value: str) -> Track:
+    def _effective_locale(self, locale: str | None) -> str | None:
+        return urls.normalize_locale(locale) if locale is not None else self._locale
+
+    def get_track(self, value: str, *, locale: str | None = None) -> Track:
         """Fetch a track by URL, URI, or bare ID.
 
         The embed page is fetched first: it supplies the tier-2 fallback
@@ -124,15 +137,19 @@ class SpotifyClient:
 
         Args:
             value: A Spotify track URL, URI, or 22-character ID.
+            locale: Per-call display-language override (``Accept-Language``);
+                localizes display-name LANGUAGE only, not availability/preview.
 
         Returns:
             The richest available :class:`Track`.
 
         Raises:
+            URLError: If ``locale`` is invalid.
             NotFoundError: If the track does not exist.
             SpotifyScraperError: If the client is closed.
         """
         _, entity_id = self._resolve(value, "track")
+        effective = self._effective_locale(locale)
         model, _, _, _ = self._get_entity(
             "track",
             entity_id,
@@ -140,30 +157,36 @@ class SpotifyClient:
             parse_entities.parse_track_gql,
             parse_entities.parse_track_embed,
             merge=parse_entities._merge_tracks,
+            locale=effective,
         )
         return model
 
-    def get_album(self, value: str) -> Album:
+    def get_album(self, value: str, *, locale: str | None = None) -> Album:
         """Fetch an album by URL, URI, or bare ID, paginating its tracks.
 
         Args:
             value: A Spotify album URL, URI, or 22-character ID.
+            locale: Per-call display-language override (``Accept-Language``);
+                localizes display-name LANGUAGE only, not availability/preview.
 
         Returns:
             The richest available :class:`Album` with as many tracks as the
             pathfinder pages provided (all of them by default).
 
         Raises:
+            URLError: If ``locale`` is invalid.
             NotFoundError: If the album does not exist.
             SpotifyScraperError: If the client is closed.
         """
         _, entity_id = self._resolve(value, "album")
+        effective = self._effective_locale(locale)
         album, session, tier1, union = self._get_entity(
             "album",
             entity_id,
             "albumUnion",
             parse_entities.parse_album_gql,
             parse_entities.parse_album_embed,
+            locale=effective,
         )
         if not tier1 or union is None:
             return album
@@ -179,55 +202,68 @@ class SpotifyClient:
             page_size=_ALBUM_PAGE,
             max_items=None,
             parse_page=parse_entities.parse_album_tracks_page,
+            locale=effective,
         )
         if not tracks:
             return album
         return _with_album_tracks(album, (*album.tracks, *tracks))
 
-    def get_artist(self, value: str) -> Artist:
+    def get_artist(self, value: str, *, locale: str | None = None) -> Artist:
         """Fetch an artist by URL, URI, or bare ID.
 
         Args:
             value: A Spotify artist URL, URI, or 22-character ID.
+            locale: Per-call display-language override (``Accept-Language``);
+                localizes display-name LANGUAGE only, not availability/preview.
 
         Returns:
             The richest available :class:`Artist`.
 
         Raises:
+            URLError: If ``locale`` is invalid.
             NotFoundError: If the artist does not exist.
             SpotifyScraperError: If the client is closed.
         """
         _, entity_id = self._resolve(value, "artist")
+        effective = self._effective_locale(locale)
         artist, _, _, _ = self._get_entity(
             "artist",
             entity_id,
             "artistUnion",
             parse_entities.parse_artist_gql,
             parse_entities.parse_artist_embed,
+            locale=effective,
         )
         return artist
 
-    def get_playlist(self, value: str, *, max_tracks: int | None = 100) -> Playlist:
+    def get_playlist(
+        self, value: str, *, max_tracks: int | None = 100, locale: str | None = None
+    ) -> Playlist:
         """Fetch a playlist by URL, URI, or bare ID, paginating its tracks.
 
         Args:
             value: A Spotify playlist URL, URI, or 22-character ID.
             max_tracks: Upper bound on tracks to collect; ``None`` fetches all.
+            locale: Per-call display-language override (``Accept-Language``);
+                localizes display-name LANGUAGE only, not availability/preview.
 
         Returns:
             The richest available :class:`Playlist`.
 
         Raises:
+            URLError: If ``locale`` is invalid.
             NotFoundError: If the playlist does not exist.
             SpotifyScraperError: If the client is closed.
         """
         _, entity_id = self._resolve(value, "playlist")
+        effective = self._effective_locale(locale)
         playlist, session, tier1, union = self._get_entity(
             "playlist",
             entity_id,
             "playlistV2",
             lambda union: parse_entities.parse_playlist_gql(union, max_tracks=max_tracks),
             parse_entities.parse_playlist_embed,
+            locale=effective,
         )
         if not tier1 or union is None:
             return playlist
@@ -243,61 +279,74 @@ class SpotifyClient:
             page_size=_PLAYLIST_PAGE,
             max_items=max_tracks,
             parse_page=parse_entities.parse_playlist_tracks_page,
+            locale=effective,
         )
         if not tracks:
             return playlist
         return _with_playlist_tracks(playlist, (*playlist.tracks, *tracks))
 
-    def get_episode(self, value: str) -> Episode:
+    def get_episode(self, value: str, *, locale: str | None = None) -> Episode:
         """Fetch a podcast episode by URL, URI, or bare ID.
 
         Args:
             value: A Spotify episode URL, URI, or 22-character ID.
+            locale: Per-call display-language override (``Accept-Language``);
+                localizes display-name LANGUAGE only, not availability/preview.
 
         Returns:
             The richest available :class:`Episode`.
 
         Raises:
+            URLError: If ``locale`` is invalid.
             NotFoundError: If the episode does not exist.
             SpotifyScraperError: If the client is closed.
         """
         _, entity_id = self._resolve(value, "episode")
+        effective = self._effective_locale(locale)
         episode, _, _, _ = self._get_entity(
             "episode",
             entity_id,
             "episodeUnionV2",
             parse_entities.parse_episode_gql,
             parse_entities.parse_episode_embed,
+            locale=effective,
         )
         return episode
 
-    def get_show(self, value: str, *, max_episodes: int | None = 50) -> Show:
+    def get_show(
+        self, value: str, *, max_episodes: int | None = 50, locale: str | None = None
+    ) -> Show:
         """Fetch a podcast show by URL, URI, or bare ID, listing its episodes.
 
         Args:
             value: A Spotify show URL, URI, or 22-character ID.
             max_episodes: Upper bound on episodes to collect; ``None`` fetches
                 all of them.
+            locale: Per-call display-language override (``Accept-Language``);
+                localizes display-name LANGUAGE only, not availability/preview.
 
         Returns:
             The richest available :class:`Show`, with ``total_episodes`` and a
             paginated ``episodes`` listing when tier 1 succeeds.
 
         Raises:
+            URLError: If ``locale`` is invalid.
             NotFoundError: If the show does not exist.
             SpotifyScraperError: If the client is closed.
         """
         _, entity_id = self._resolve(value, "show")
+        effective = self._effective_locale(locale)
         show, session, tier1, _ = self._get_entity(
             "show",
             entity_id,
             "podcastUnionV2",
             parse_entities.parse_show_gql,
             parse_entities.parse_show_embed,
+            locale=effective,
         )
         if not tier1:
             return show
-        return self._with_episodes(show, entity_id, session, max_episodes)
+        return self._with_episodes(show, entity_id, session, max_episodes, locale=effective)
 
     def get_lyrics(self, value: str) -> Lyrics:
         """Fetch a track's lyrics using the cookie-derived web-player token.
@@ -333,6 +382,7 @@ class SpotifyClient:
         *,
         types: Sequence[str] = _SEARCH_TYPES,
         limit: int = 20,
+        locale: str | None = None,
     ) -> SearchResults:
         """Search Spotify for tracks, albums, artists, playlists, shows, episodes.
 
@@ -347,18 +397,22 @@ class SpotifyClient:
                 ``"track"``, ``"album"``, ``"artist"``, ``"playlist"``,
                 ``"show"``, and ``"episode"``.
             limit: Maximum hits per section requested from Spotify.
+            locale: Per-call display-language override (``Accept-Language``);
+                localizes display-name LANGUAGE only, not availability/preview.
 
         Returns:
             A :class:`SearchResults` whose tuples for the requested ``types`` are
             populated; unrequested types stay empty.
 
         Raises:
-            URLError: If ``types`` contains an unrecognized entity type.
+            URLError: If ``types`` contains an unrecognized entity type, or
+                ``locale`` is invalid.
             SpotifyScraperError: If the client is closed.
         """
         self._ensure_open()
         wanted = _validate_search_types(types)
-        union = self._search_union(query, limit)
+        effective = self._effective_locale(locale)
+        union = self._search_union(query, limit, locale=effective)
         results = parse_entities.parse_search_results(union, query=query)
         return _filter_search_results(results, wanted)
 
@@ -452,7 +506,13 @@ class SpotifyClient:
         )
 
     def _with_episodes(
-        self, show: Show, entity_id: str, session: EmbedSession, max_episodes: int | None
+        self,
+        show: Show,
+        entity_id: str,
+        session: EmbedSession,
+        max_episodes: int | None,
+        *,
+        locale: str | None = None,
     ) -> Show:
         first_limit = (
             _SHOW_EPISODES_PAGE if max_episodes is None else min(max_episodes, _SHOW_EPISODES_PAGE)
@@ -464,6 +524,7 @@ class SpotifyClient:
                 "podcastUnionV2",
                 session,
                 overrides={"offset": 0, "limit": first_limit},
+                locale=locale,
             )
         except (ParsingError, SpotifyScraperError) as exc:
             _LOGGER.warning("Show episode listing for %s failed: %s", entity_id, exc)
@@ -483,6 +544,7 @@ class SpotifyClient:
                 page_size=_SHOW_EPISODES_PAGE,
                 max_items=max_episodes,
                 parse_page=parse_entities.parse_show_episodes_page,
+                locale=locale,
             )
         )
         if max_episodes is not None:
@@ -525,6 +587,7 @@ class SpotifyClient:
         parse_embed_fn: Callable[[Mapping[str, Any]], _T],
         *,
         merge: Callable[[_T, _T], _T] | None = None,
+        locale: str | None = None,
     ) -> tuple[_T, EmbedSession, bool, Mapping[str, Any] | None]:
         """Run the embed-first two-tier ladder for one entity.
 
@@ -533,12 +596,12 @@ class SpotifyClient:
         the raw tier-1 union (so paginating callers can count raw items) or
         ``None`` when degraded.
         """
-        next_data = self._fetch_next_data(kind, entity_id)
+        next_data = self._fetch_next_data(kind, entity_id, locale=locale)
         embed_model = parse_embed_fn(parse_embed.get_entity(next_data))
         session = parse_embed.get_session(next_data)
 
         try:
-            union = self._fetch_union(kind, entity_id, union_key, session)
+            union = self._fetch_union(kind, entity_id, union_key, session, locale=locale)
             gql_model = parse_gql(union)
         except (ParsingError, NetworkError) as exc:
             _LOGGER.warning("Tier-1 %s fetch degraded to embed page: %s", kind, exc)
@@ -561,6 +624,7 @@ class SpotifyClient:
         page_size: int,
         max_items: int | None,
         parse_page: Callable[[Mapping[str, Any]], tuple[_T, ...]],
+        locale: str | None = None,
     ) -> tuple[_T, ...]:
         """Fetch follow-up pages after the first tier-1 page.
 
@@ -584,6 +648,7 @@ class SpotifyClient:
                     union_key,
                     session,
                     overrides={"offset": offset, "limit": page_size},
+                    locale=locale,
                 )
                 page = parse_page(union)
             except (ParsingError, SpotifyScraperError) as exc:
@@ -598,8 +663,13 @@ class SpotifyClient:
             return tuple(extra[: max(0, max_items - filtered_have)])
         return tuple(extra)
 
-    def _fetch_next_data(self, kind: str, entity_id: str) -> dict[str, Any]:
-        response: Response = self._transport.get(urls.embed_url(kind, entity_id))  # type: ignore[arg-type]
+    def _fetch_next_data(
+        self, kind: str, entity_id: str, *, locale: str | None = None
+    ) -> dict[str, Any]:
+        response: Response = self._transport.get(
+            urls.embed_url(kind, entity_id),  # type: ignore[arg-type]
+            headers=_lang_header(locale),
+        )
         return parse_embed.extract_next_data(response.text)
 
     def _fetch_union(
@@ -610,12 +680,17 @@ class SpotifyClient:
         session: EmbedSession,
         *,
         overrides: Mapping[str, Any] | None = None,
+        locale: str | None = None,
     ) -> Mapping[str, Any]:
         try:
-            data = self._pathfinder_request(kind, entity_id, session.access_token, overrides)
+            data = self._pathfinder_request(
+                kind, entity_id, session.access_token, overrides, locale
+            )
         except TokenError:
             self._tokens.invalidate()
-            data = self._pathfinder_request(kind, entity_id, self._tokens.token(), overrides)
+            data = self._pathfinder_request(
+                kind, entity_id, self._tokens.token(), overrides, locale
+            )
         union = data.get(union_key)
         if not isinstance(union, Mapping):
             raise ParsingError(
@@ -630,19 +705,23 @@ class SpotifyClient:
         entity_id: str,
         token: str,
         overrides: Mapping[str, Any] | None,
+        locale: str | None = None,
     ) -> dict[str, Any]:
         url = pathfinder.build_url(kind, entity_id, variable_overrides=overrides)
-        response = self._transport.get(url, headers=pathfinder.auth_headers(token))
+        headers = {**pathfinder.auth_headers(token), **_lang_header(locale)}
+        response = self._transport.get(url, headers=headers)
         body = _safe_json(response)
         return pathfinder.classify_response(response.status_code, body)
 
-    def _search_union(self, query: str, limit: int) -> Mapping[str, Any]:
+    def _search_union(
+        self, query: str, limit: int, *, locale: str | None = None
+    ) -> Mapping[str, Any]:
         overrides = {"limit": limit}
         try:
-            data = self._search_request(query, self._tokens.token(), overrides)
+            data = self._search_request(query, self._tokens.token(), overrides, locale)
         except TokenError:
             self._tokens.invalidate()
-            data = self._search_request(query, self._tokens.token(), overrides)
+            data = self._search_request(query, self._tokens.token(), overrides, locale)
         union = data.get("searchV2")
         if not isinstance(union, Mapping):
             raise ParsingError(
@@ -656,11 +735,22 @@ class SpotifyClient:
         query: str,
         token: str,
         overrides: Mapping[str, Any] | None,
+        locale: str | None = None,
     ) -> dict[str, Any]:
         url = pathfinder.build_search_url(query, variable_overrides=overrides)
-        response = self._transport.get(url, headers=pathfinder.auth_headers(token))
+        headers = {**pathfinder.auth_headers(token), **_lang_header(locale)}
+        response = self._transport.get(url, headers=headers)
         body = _safe_json(response)
         return pathfinder.classify_response(response.status_code, body)
+
+
+def _lang_header(locale: str | None) -> dict[str, str]:
+    """Return a per-request ``Accept-Language`` override, or empty when unset.
+
+    The override wins over the transport default (``Accept-Language: en``) in
+    ``transport.get``, localizing display-name LANGUAGE only.
+    """
+    return {"Accept-Language": locale} if locale is not None else {}
 
 
 def _validate_search_types(types: Sequence[str]) -> frozenset[str]:

--- a/src/spotify_scraper/urls.py
+++ b/src/spotify_scraper/urls.py
@@ -22,6 +22,8 @@ ENTITY_TYPES: frozenset[str] = frozenset(
 _HOSTS = frozenset({"open.spotify.com", "play.spotify.com"})
 _ID_RE = re.compile(r"[0-9A-Za-z]{22}")
 _INTL_RE = re.compile(r"intl-[A-Za-z]+(?:-[A-Za-z]+)?")
+_MARKET_RE = re.compile(r"[A-Za-z]{2}")
+_LOCALE_RE = re.compile(r"[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})+")
 
 
 def parse(value: str, *, type_hint: EntityType | None = None) -> tuple[EntityType, str]:
@@ -50,6 +52,39 @@ def parse(value: str, *, type_hint: EntityType | None = None) -> tuple[EntityTyp
     if text.startswith("spotify:"):
         return _parse_uri(text)
     return _parse_url(text)
+
+
+def normalize_locale(value: str) -> str:
+    """Validate and normalize a locale for the ``Accept-Language`` header.
+
+    Accepts either a bare ISO-3166 alpha-2 country code (case-insensitive,
+    returned upper-cased, e.g. ``"de"`` -> ``"DE"``) or a full language-region
+    tag (returned unchanged, e.g. ``"ja-JP"``, ``"en-US"``).
+
+    This sets the *display language* of localized names only; on the anonymous
+    ladder it does NOT filter regional availability or vary preview URLs (the
+    pathfinder ``market`` variable is inert and the token's country is
+    IP-bound). True market/availability requires the authenticated Web API.
+
+    Args:
+        value: A country code or language tag.
+
+    Returns:
+        The normalized locale string.
+
+    Raises:
+        URLError: If ``value`` is neither a valid alpha-2 code nor a valid
+            language-region tag.
+    """
+    text = value.strip()
+    if _MARKET_RE.fullmatch(text):
+        return text.upper()
+    if _LOCALE_RE.fullmatch(text):
+        return text
+    raise URLError(
+        f"Invalid locale {value!r}: expected an ISO-3166 alpha-2 code "
+        "(e.g. 'US') or a language tag (e.g. 'ja-JP')."
+    )
 
 
 def entity_url(entity_type: EntityType, entity_id: str) -> str:

--- a/src/spotify_scraper/urls.py
+++ b/src/spotify_scraper/urls.py
@@ -22,8 +22,8 @@ ENTITY_TYPES: frozenset[str] = frozenset(
 _HOSTS = frozenset({"open.spotify.com", "play.spotify.com"})
 _ID_RE = re.compile(r"[0-9A-Za-z]{22}")
 _INTL_RE = re.compile(r"intl-[A-Za-z]+(?:-[A-Za-z]+)?")
-_MARKET_RE = re.compile(r"[A-Za-z]{2}")
-_LOCALE_RE = re.compile(r"[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})+")
+_LANG_RE = re.compile(r"[A-Za-z]{2,3}")
+_LANG_REGION_RE = re.compile(r"[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})+")
 
 
 def parse(value: str, *, type_hint: EntityType | None = None) -> tuple[EntityType, str]:
@@ -55,35 +55,37 @@ def parse(value: str, *, type_hint: EntityType | None = None) -> tuple[EntityTyp
 
 
 def normalize_locale(value: str) -> str:
-    """Validate and normalize a locale for the ``Accept-Language`` header.
+    """Validate and normalize a display-language tag for ``Accept-Language``.
 
-    Accepts either a bare ISO-3166 alpha-2 country code (case-insensitive,
-    returned upper-cased, e.g. ``"de"`` -> ``"DE"``) or a full language-region
-    tag (returned unchanged, e.g. ``"ja-JP"``, ``"en-US"``).
+    ``locale`` here is a **BCP-47 language tag**, not a country/market code. It
+    accepts either a bare primary language subtag (2-3 letters, normalized to
+    lower-case, e.g. ``"de"``, ``"en"``, ``"por"``) or a language-region tag
+    (returned unchanged, e.g. ``"ja-JP"``, ``"en-US"``).
 
-    This sets the *display language* of localized names only; on the anonymous
-    ladder it does NOT filter regional availability or vary preview URLs (the
-    pathfinder ``market`` variable is inert and the token's country is
-    IP-bound). True market/availability requires the authenticated Web API.
+    It sets the *display language* of localized names only. It does NOT filter
+    regional availability or vary preview URLs: a bare country code like ``"US"``
+    is meaningless as a language and is silently ignored by Spotify. On the
+    anonymous ladder the pathfinder ``market`` variable is inert and the token's
+    country is IP-bound, so true market/availability requires the authenticated
+    Web API (not implemented here).
 
     Args:
-        value: A country code or language tag.
+        value: A BCP-47 language tag (e.g. ``"en"``, ``"ja-JP"``).
 
     Returns:
-        The normalized locale string.
+        The normalized language tag (bare subtags lower-cased).
 
     Raises:
-        URLError: If ``value`` is neither a valid alpha-2 code nor a valid
-            language-region tag.
+        URLError: If ``value`` is not a valid language or language-region tag.
     """
     text = value.strip()
-    if _MARKET_RE.fullmatch(text):
-        return text.upper()
-    if _LOCALE_RE.fullmatch(text):
+    if _LANG_REGION_RE.fullmatch(text):
         return text
+    if _LANG_RE.fullmatch(text):
+        return text.lower()
     raise URLError(
-        f"Invalid locale {value!r}: expected an ISO-3166 alpha-2 code "
-        "(e.g. 'US') or a language tag (e.g. 'ja-JP')."
+        f"Invalid language tag {value!r}: expected a BCP-47 language tag "
+        "like 'en', 'ja', or 'ja-JP'."
     )
 
 

--- a/tests/live/test_locale.py
+++ b/tests/live/test_locale.py
@@ -1,0 +1,48 @@
+"""Live smoke tests for ``locale`` display-language localization (no cookie).
+
+Proves the ``Accept-Language`` lever works end to end: a Japanese locale yields
+a transliterated (non-ASCII) artist display name that differs from the default
+English one. A negative-scope guard documents the honest limitation — ``locale``
+localizes display-name LANGUAGE only; it does NOT change availability/playability
+(true regional availability/market is not achievable anonymously).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from spotify_scraper import SpotifyClient
+
+# "Never Gonna Give You Up" — Rick Astley transliterates to リック・アストリー under ja.
+NEVER_GONNA = "4uLU6hMCjMI75M1A2tKUQC"
+
+
+def _is_ascii(text: str) -> bool:
+    return text.isascii()
+
+
+@pytest.mark.live
+def test_locale_localizes_artist_name() -> None:
+    with SpotifyClient() as client:  # no cookie
+        default_track = client.get_track(NEVER_GONNA)
+        ja_track = client.get_track(NEVER_GONNA, locale="ja")
+
+    default_name = default_track.artists[0].name
+    ja_name = ja_track.artists[0].name
+
+    assert ja_name != default_name
+    assert _is_ascii(default_name)
+    assert not _is_ascii(ja_name)
+
+
+@pytest.mark.live
+def test_locale_does_not_change_availability() -> None:
+    # Negative-scope guard: locale is a language lever, not a market lever.
+    with SpotifyClient() as client:
+        en_track = client.get_track(NEVER_GONNA, locale="en")
+        ja_track = client.get_track(NEVER_GONNA, locale="ja")
+
+    assert en_track.explicit == ja_track.explicit
+    assert en_track.playable == ja_track.playable
+    assert en_track.duration_ms == ja_track.duration_ms
+    assert (en_track.preview_url is None) == (ja_track.preview_url is None)

--- a/tests/unit/test_client_entities.py
+++ b/tests/unit/test_client_entities.py
@@ -226,6 +226,34 @@ def test_playlist_pagination_collects_all_pages() -> None:
 
 
 @respx.mock
+def test_playlist_pagination_carries_locale_on_every_page() -> None:
+    # A per-client locale must reach the SECOND (pagination) pathfinder request,
+    # not only the first.
+    first = _playlist_page(range(0, 25))
+    second = _playlist_page(range(25, 50))
+    embed = respx.get(_embed_url("playlist", IDS["playlist"])).mock(
+        return_value=httpx.Response(200, text=_embed_html("playlist"))
+    )
+    pathfinder_route = respx.get(PATHFINDER_RE).mock(
+        side_effect=[
+            httpx.Response(200, json=first),
+            httpx.Response(200, json=second),
+        ]
+    )
+
+    with SpotifyClient(locale="ja-JP") as client:
+        playlist = client.get_playlist(IDS["playlist"], max_tracks=None)
+
+    assert len(playlist.tracks) == 50
+    assert pathfinder_route.call_count == 2
+    # Both pages — and the embed bootstrap — carry the Accept-Language header.
+    assert embed.calls.last.request.headers["Accept-Language"] == "ja-JP"
+    assert all(
+        call.request.headers["Accept-Language"] == "ja-JP" for call in pathfinder_route.calls
+    )
+
+
+@respx.mock
 def test_playlist_pagination_stops_at_max_tracks() -> None:
     respx.get(_embed_url("playlist", IDS["playlist"])).mock(
         return_value=httpx.Response(200, text=_embed_html("playlist"))

--- a/tests/unit/test_client_locale.py
+++ b/tests/unit/test_client_locale.py
@@ -1,0 +1,181 @@
+"""respx-driven tests for the ``locale`` (``Accept-Language``) parameter.
+
+Covers both clients: the per-client default and per-call override both set the
+``Accept-Language`` header on the pathfinder (and embed) requests; per-call wins
+over per-client; an invalid locale raises ``URLError`` with ZERO network calls at
+both construction and call time; an omitted locale sends no override; and the
+header is applied to ``search`` too.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from spotify_scraper import AsyncSpotifyClient, SpotifyClient
+from spotify_scraper.auth.anonymous import DEFAULT_BOOTSTRAP_ID
+from spotify_scraper.errors import URLError
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+TRACK_ID = "4uLU6hMCjMI75M1A2tKUQC"
+EMBED_URL = f"https://open.spotify.com/embed/track/{TRACK_ID}"
+BOOTSTRAP_URL = f"https://open.spotify.com/embed/track/{DEFAULT_BOOTSTRAP_ID}"
+PATHFINDER_RE = re.compile(r"https://api-partner\.spotify\.com/pathfinder/v1/query.*")
+
+EMBED_NEXT_DATA: dict[str, Any] = json.loads((FIXTURES / "embed" / "track.json").read_text())
+PATHFINDER_BODY: dict[str, Any] = json.loads((FIXTURES / "pathfinder" / "track.json").read_text())
+SEARCH_BODY: dict[str, Any] = json.loads((FIXTURES / "pathfinder" / "search.json").read_text())
+
+
+def _embed_html(*, token: str = "EMBED_TOKEN") -> str:  # noqa: S107
+    next_data = json.loads(json.dumps(EMBED_NEXT_DATA))
+    session = next_data["props"]["pageProps"]["state"]["settings"]["session"]
+    session["accessToken"] = token
+    session["accessTokenExpirationTimestampMs"] = 9_999_999_999_999
+    body = json.dumps(next_data)
+    return f'<script id="__NEXT_DATA__" type="application/json">{body}</script>'
+
+
+def _mock_track() -> respx.Route:
+    respx.get(EMBED_URL).mock(return_value=httpx.Response(200, text=_embed_html()))
+    return respx.get(PATHFINDER_RE).mock(return_value=httpx.Response(200, json=PATHFINDER_BODY))
+
+
+def _mock_search() -> respx.Route:
+    respx.get(BOOTSTRAP_URL).mock(return_value=httpx.Response(200, text=_embed_html()))
+    return respx.get(PATHFINDER_RE).mock(return_value=httpx.Response(200, json=SEARCH_BODY))
+
+
+# --------------------------------------------------------------------------- #
+# Sync
+# --------------------------------------------------------------------------- #
+
+
+@respx.mock
+def test_per_client_locale_sets_accept_language() -> None:
+    embed = respx.get(EMBED_URL).mock(return_value=httpx.Response(200, text=_embed_html()))
+    pathfinder = respx.get(PATHFINDER_RE).mock(
+        return_value=httpx.Response(200, json=PATHFINDER_BODY)
+    )
+    with SpotifyClient(locale="ja-JP") as client:
+        client.get_track(TRACK_ID)
+    assert pathfinder.calls.last.request.headers["Accept-Language"] == "ja-JP"
+    assert embed.calls.last.request.headers["Accept-Language"] == "ja-JP"
+
+
+@respx.mock
+def test_per_call_locale_overrides_per_client() -> None:
+    pathfinder = _mock_track()
+    with SpotifyClient(locale="de-DE") as client:
+        client.get_track(TRACK_ID, locale="ja-JP")
+    assert pathfinder.calls.last.request.headers["Accept-Language"] == "ja-JP"
+
+
+@respx.mock
+def test_bare_country_code_is_upper_cased_on_the_wire() -> None:
+    pathfinder = _mock_track()
+    with SpotifyClient() as client:
+        client.get_track(TRACK_ID, locale="de")
+    assert pathfinder.calls.last.request.headers["Accept-Language"] == "DE"
+
+
+@respx.mock
+def test_omitted_locale_sends_default_en_only() -> None:
+    pathfinder = _mock_track()
+    with SpotifyClient() as client:
+        client.get_track(TRACK_ID)
+    assert pathfinder.calls.last.request.headers["Accept-Language"] == "en"
+
+
+@respx.mock
+def test_invalid_per_call_locale_raises_before_any_request() -> None:
+    pathfinder = respx.get(PATHFINDER_RE).mock(return_value=httpx.Response(200, json={}))
+    embed = respx.get(EMBED_URL).mock(return_value=httpx.Response(200, text=_embed_html()))
+    with SpotifyClient() as client, pytest.raises(URLError, match="USA"):
+        client.get_track(TRACK_ID, locale="USA")
+    assert pathfinder.call_count == 0
+    assert embed.call_count == 0
+
+
+def test_invalid_construction_locale_raises_without_network() -> None:
+    with pytest.raises(URLError, match="u1"):
+        SpotifyClient(locale="u1")
+
+
+@respx.mock
+def test_search_carries_resolved_locale() -> None:
+    pathfinder = _mock_search()
+    with SpotifyClient(locale="de") as client:
+        client.search("daft punk", locale="ja-JP")
+    assert pathfinder.calls.last.request.headers["Accept-Language"] == "ja-JP"
+
+
+@respx.mock
+def test_search_invalid_locale_raises_before_request() -> None:
+    pathfinder = respx.get(PATHFINDER_RE).mock(return_value=httpx.Response(200, json={}))
+    with SpotifyClient() as client, pytest.raises(URLError):
+        client.search("daft punk", locale="123")
+    assert pathfinder.call_count == 0
+
+
+# --------------------------------------------------------------------------- #
+# Async
+# --------------------------------------------------------------------------- #
+
+
+@respx.mock
+async def test_per_client_locale_sets_accept_language_async() -> None:
+    embed = respx.get(EMBED_URL).mock(return_value=httpx.Response(200, text=_embed_html()))
+    pathfinder = respx.get(PATHFINDER_RE).mock(
+        return_value=httpx.Response(200, json=PATHFINDER_BODY)
+    )
+    async with AsyncSpotifyClient(locale="ja-JP") as client:
+        await client.get_track(TRACK_ID)
+    assert pathfinder.calls.last.request.headers["Accept-Language"] == "ja-JP"
+    assert embed.calls.last.request.headers["Accept-Language"] == "ja-JP"
+
+
+@respx.mock
+async def test_per_call_locale_overrides_per_client_async() -> None:
+    pathfinder = _mock_track()
+    async with AsyncSpotifyClient(locale="de-DE") as client:
+        await client.get_track(TRACK_ID, locale="ja-JP")
+    assert pathfinder.calls.last.request.headers["Accept-Language"] == "ja-JP"
+
+
+@respx.mock
+async def test_omitted_locale_sends_default_en_only_async() -> None:
+    pathfinder = _mock_track()
+    async with AsyncSpotifyClient() as client:
+        await client.get_track(TRACK_ID)
+    assert pathfinder.calls.last.request.headers["Accept-Language"] == "en"
+
+
+@respx.mock
+async def test_invalid_per_call_locale_raises_before_any_request_async() -> None:
+    pathfinder = respx.get(PATHFINDER_RE).mock(return_value=httpx.Response(200, json={}))
+    embed = respx.get(EMBED_URL).mock(return_value=httpx.Response(200, text=_embed_html()))
+    async with AsyncSpotifyClient() as client:
+        with pytest.raises(URLError, match="USA"):
+            await client.get_track(TRACK_ID, locale="USA")
+    assert pathfinder.call_count == 0
+    assert embed.call_count == 0
+
+
+def test_invalid_construction_locale_raises_without_network_async() -> None:
+    with pytest.raises(URLError):
+        AsyncSpotifyClient(locale="u1")
+
+
+@respx.mock
+async def test_search_carries_resolved_locale_async() -> None:
+    pathfinder = _mock_search()
+    async with AsyncSpotifyClient(locale="de") as client:
+        await client.search("daft punk", locale="ja-JP")
+    assert pathfinder.calls.last.request.headers["Accept-Language"] == "ja-JP"

--- a/tests/unit/test_client_locale.py
+++ b/tests/unit/test_client_locale.py
@@ -84,11 +84,11 @@ def test_per_call_locale_overrides_per_client() -> None:
 
 
 @respx.mock
-def test_bare_country_code_is_upper_cased_on_the_wire() -> None:
+def test_bare_language_subtag_is_lower_cased_on_the_wire() -> None:
     pathfinder = _mock_track()
     with SpotifyClient() as client:
-        client.get_track(TRACK_ID, locale="de")
-    assert pathfinder.calls.last.request.headers["Accept-Language"] == "DE"
+        client.get_track(TRACK_ID, locale="DE")
+    assert pathfinder.calls.last.request.headers["Accept-Language"] == "de"
 
 
 @respx.mock
@@ -103,8 +103,8 @@ def test_omitted_locale_sends_default_en_only() -> None:
 def test_invalid_per_call_locale_raises_before_any_request() -> None:
     pathfinder = respx.get(PATHFINDER_RE).mock(return_value=httpx.Response(200, json={}))
     embed = respx.get(EMBED_URL).mock(return_value=httpx.Response(200, text=_embed_html()))
-    with SpotifyClient() as client, pytest.raises(URLError, match="USA"):
-        client.get_track(TRACK_ID, locale="USA")
+    with SpotifyClient() as client, pytest.raises(URLError, match="deutsch"):
+        client.get_track(TRACK_ID, locale="deutsch")
     assert pathfinder.call_count == 0
     assert embed.call_count == 0
 
@@ -168,8 +168,8 @@ async def test_invalid_per_call_locale_raises_before_any_request_async() -> None
     pathfinder = respx.get(PATHFINDER_RE).mock(return_value=httpx.Response(200, json={}))
     embed = respx.get(EMBED_URL).mock(return_value=httpx.Response(200, text=_embed_html()))
     async with AsyncSpotifyClient() as client:
-        with pytest.raises(URLError, match="USA"):
-            await client.get_track(TRACK_ID, locale="USA")
+        with pytest.raises(URLError, match="deutsch"):
+            await client.get_track(TRACK_ID, locale="deutsch")
     assert pathfinder.call_count == 0
     assert embed.call_count == 0
 
@@ -185,3 +185,20 @@ async def test_search_carries_resolved_locale_async() -> None:
     async with AsyncSpotifyClient(locale="de") as client:
         await client.search("daft punk", locale="ja-JP")
     assert pathfinder.calls.last.request.headers["Accept-Language"] == "ja-JP"
+
+
+@respx.mock
+async def test_bare_language_subtag_is_lower_cased_on_the_wire_async() -> None:
+    pathfinder = _mock_track()
+    async with AsyncSpotifyClient() as client:
+        await client.get_track(TRACK_ID, locale="DE")
+    assert pathfinder.calls.last.request.headers["Accept-Language"] == "de"
+
+
+@respx.mock
+async def test_search_invalid_locale_raises_before_request_async() -> None:
+    pathfinder = respx.get(PATHFINDER_RE).mock(return_value=httpx.Response(200, json={}))
+    async with AsyncSpotifyClient() as client:
+        with pytest.raises(URLError):
+            await client.search("daft punk", locale="123")
+    assert pathfinder.call_count == 0

--- a/tests/unit/test_client_locale.py
+++ b/tests/unit/test_client_locale.py
@@ -28,9 +28,15 @@ EMBED_URL = f"https://open.spotify.com/embed/track/{TRACK_ID}"
 BOOTSTRAP_URL = f"https://open.spotify.com/embed/track/{DEFAULT_BOOTSTRAP_ID}"
 PATHFINDER_RE = re.compile(r"https://api-partner\.spotify\.com/pathfinder/v1/query.*")
 
-EMBED_NEXT_DATA: dict[str, Any] = json.loads((FIXTURES / "embed" / "track.json").read_text())
-PATHFINDER_BODY: dict[str, Any] = json.loads((FIXTURES / "pathfinder" / "track.json").read_text())
-SEARCH_BODY: dict[str, Any] = json.loads((FIXTURES / "pathfinder" / "search.json").read_text())
+EMBED_NEXT_DATA: dict[str, Any] = json.loads(
+    (FIXTURES / "embed" / "track.json").read_text(encoding="utf-8")
+)
+PATHFINDER_BODY: dict[str, Any] = json.loads(
+    (FIXTURES / "pathfinder" / "track.json").read_text(encoding="utf-8")
+)
+SEARCH_BODY: dict[str, Any] = json.loads(
+    (FIXTURES / "pathfinder" / "search.json").read_text(encoding="utf-8")
+)
 
 
 def _embed_html(*, token: str = "EMBED_TOKEN") -> str:  # noqa: S107

--- a/tests/unit/test_urls.py
+++ b/tests/unit/test_urls.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 import pytest
 
 from spotify_scraper.errors import URLError
-from spotify_scraper.urls import ENTITY_TYPES, EntityType, embed_url, entity_uri, entity_url, parse
+from spotify_scraper.urls import (
+    ENTITY_TYPES,
+    EntityType,
+    embed_url,
+    entity_uri,
+    entity_url,
+    normalize_locale,
+    parse,
+)
 
 TRACK_ID = "4uLU6hMCjMI75M1A2tKUQC"
 ALBUM_ID = "4aawyAB9vmqN3uQ7FjRGTy"
@@ -154,3 +162,41 @@ def test_url_construction_round_trips(entity_type: EntityType, entity_id: str) -
 
 def test_embed_url_for_token_bootstrap() -> None:
     assert embed_url("track", TRACK_ID) == f"https://open.spotify.com/embed/track/{TRACK_ID}"
+
+
+# --------------------------------------------------------------------------- #
+# normalize_locale
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("de", "DE"),
+        ("DE", "DE"),
+        ("us", "US"),
+        ("GB", "GB"),
+        ("  jp  ", "JP"),
+        ("ja-JP", "ja-JP"),
+        ("en-US", "en-US"),
+        ("pt-BR", "pt-BR"),
+        ("zh-Hant-TW", "zh-Hant-TW"),
+        ("  de-DE  ", "de-DE"),
+    ],
+)
+def test_normalize_locale_accepts(value: str, expected: str) -> None:
+    assert normalize_locale(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", "   ", "USA", "u1", "123", "x_y", "x-y-z", "d", "deutsch", "ja--JP", "en-"],
+)
+def test_normalize_locale_rejects(value: str) -> None:
+    with pytest.raises(URLError):
+        normalize_locale(value)
+
+
+def test_normalize_locale_error_names_value() -> None:
+    with pytest.raises(URLError, match="USA"):
+        normalize_locale("USA")

--- a/tests/unit/test_urls.py
+++ b/tests/unit/test_urls.py
@@ -172,11 +172,13 @@ def test_embed_url_for_token_bootstrap() -> None:
 @pytest.mark.parametrize(
     ("value", "expected"),
     [
-        ("de", "DE"),
-        ("DE", "DE"),
-        ("us", "US"),
-        ("GB", "GB"),
-        ("  jp  ", "JP"),
+        # Bare language subtags are normalized to lower-case (BCP-47 convention).
+        ("de", "de"),
+        ("DE", "de"),
+        ("en", "en"),
+        ("  ja  ", "ja"),
+        ("por", "por"),  # a valid bare 3-letter language subtag
+        # Language-region tags are returned unchanged.
         ("ja-JP", "ja-JP"),
         ("en-US", "en-US"),
         ("pt-BR", "pt-BR"),
@@ -190,7 +192,7 @@ def test_normalize_locale_accepts(value: str, expected: str) -> None:
 
 @pytest.mark.parametrize(
     "value",
-    ["", "   ", "USA", "u1", "123", "x_y", "x-y-z", "d", "deutsch", "ja--JP", "en-"],
+    ["", "   ", "u1", "123", "x_y", "x-y-z", "d", "deutsch", "ja--JP", "en-"],
 )
 def test_normalize_locale_rejects(value: str) -> None:
     with pytest.raises(URLError):
@@ -198,5 +200,5 @@ def test_normalize_locale_rejects(value: str) -> None:
 
 
 def test_normalize_locale_error_names_value() -> None:
-    with pytest.raises(URLError, match="USA"):
-        normalize_locale("USA")
+    with pytest.raises(URLError, match="deutsch"):
+        normalize_locale("deutsch")


### PR DESCRIPTION
Addresses #130 (v3.4). Spec-first: `openspec/changes/add-market-region-parameter/`. **Stacked on #135** (search) so `search()` gets `locale` too.

## ⚠️ Scope decision needs your sign-off (why this is a draft)
A decisive **live anonymous probe** proved true availability-`market` is **not achievable** on the anonymous endpoints this library uses: the pathfinder `market` variable is silently discarded (US/DE/JP/invalid/**bogus** all return byte-identical payloads), and the token's country is IP-bound. Shipping `market=` as a GraphQL variable would be a **no-op** — which the architecture rules (and your 'never rounded up' ethos) forbid.

So this ships the lever the probe **proved works**: an optional, validated **`locale=`** (sent as `Accept-Language`) that localizes the *language of display names*. True availability/region filtering is **scoped out and documented** (needs the authenticated Web API; use a region `proxy` otherwise).

**If you'd rather** I (a) also add a no-op-but-forward-compatible `market=` alias, (b) implement region via a proxy helper, or (c) keep it exactly as-is — tell me when back.

## Verification (fully green + live)
`locale=` on both constructors + per-call on all 6 getters and `search` (per-call wins); `urls.normalize_locale` validates alpha-2/lang-tags → `URLError`. ✅ 641 passed · mypy --strict clean · 91.31% coverage · **live test passes**: `locale="ja"` → リック・アストリー while `explicit`/`playable`/`duration_ms`/`preview_url` stay identical (proving the honest language-only scope). `api/pathfinder.py` URL building untouched.

Addresses #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)