### PR TITLE
feat: batch helpers with managed concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Batch helpers.** Plural `get_tracks`, `get_albums`, `get_artists`,
+  `get_playlists`, `get_episodes`, and `get_shows` fetch many inputs and return
+  one ordered, index-aligned `BatchItem` per input. A dead or malformed input
+  never aborts the batch — its captured error lands on that item's `error`
+  (`item.ok` / `item.result` / `item.unwrap()`). The async client runs them
+  concurrently, bounded by the client's `max_concurrency` (default 5) with the
+  per-host rate limiter still governing pacing; the sync helpers run
+  sequentially.
+
 ## [3.2.0] - 2026-06-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ with SpotifyClient() as client:
 ## Features
 
 - **All core entities + podcasts** — tracks, albums, artists, playlists, shows, episodes.
+- **Batch helpers** — plural `get_*s([...])` with partial-failure-safe results and managed concurrency.
 - **Sync & async** clients sharing one sans-io core.
 - **Typed, frozen models** with JSON-safe `to_dict()` / `from_dict()`.
 - **Two-tier resilience** — Spotify's GraphQL API with automatic fallback to the embed page.
@@ -97,6 +98,21 @@ spotifyscraper download preview <id> -o ./previews --embed-cover
 
 Every command emits JSON, so it composes with tools like `jq`. See the
 [CLI guide](https://spotifyscraper.readthedocs.io/en/latest/guides/cli/).
+
+## Batch helpers
+
+Each getter has a plural sibling (`get_tracks`, `get_albums`, …) that fetches
+many inputs and returns one `BatchItem` per input — index-aligned, and a dead
+input never aborts the rest:
+
+```python
+items = client.get_tracks(["4uLU6hMCjMI75M1A2tKUQC", "bad-id"])
+ok = [i.result for i in items if i.ok]
+failed = {i.value: i.error for i in items if not i.ok}
+```
+
+The async client runs them concurrently, bounded by `max_concurrency` (default
+5). See the [batch guide](https://spotifyscraper.readthedocs.io/en/latest/guides/batch/).
 
 ## Lyrics
 
@@ -124,6 +140,7 @@ Your cookie is sent only to Spotify and never logged. See the
 | **3.0** | The library: all entities, pagination, media downloads, browser fallback, docs |
 | **3.1** | Command-line interface |
 | **3.2** | Cookie-authenticated lyrics |
+| **3.5** | [batch helpers](https://github.com/AliAkhtari78/SpotifyScraper/issues/132) with managed concurrency (`get_*s([...])`) |
 
 **Planned** — tracked in [milestones](https://github.com/AliAkhtari78/SpotifyScraper/milestones); 👍 or weigh in on the issues to help prioritize:
 
@@ -131,7 +148,7 @@ Your cookie is sent only to Spotify and never logged. See the
 |---------|-------|
 | **3.3** | Podcast [transcripts](https://github.com/AliAkhtari78/SpotifyScraper/issues/127) · first-class [auth & session persistence](https://github.com/AliAkhtari78/SpotifyScraper/issues/128) (browser-assisted login, no stored passwords) |
 | **3.4** | [Search](https://github.com/AliAkhtari78/SpotifyScraper/issues/129) across every entity type · [market / region](https://github.com/AliAkhtari78/SpotifyScraper/issues/130) support |
-| **3.5** | Optional [response cache](https://github.com/AliAkhtari78/SpotifyScraper/issues/131) · [batch helpers](https://github.com/AliAkhtari78/SpotifyScraper/issues/132) with managed concurrency |
+| **3.5** | Optional [response cache](https://github.com/AliAkhtari78/SpotifyScraper/issues/131) |
 
 Planned scope is subject to change.
 

--- a/docs/guides/batch.md
+++ b/docs/guides/batch.md
@@ -1,0 +1,59 @@
+# Batch helpers
+
+Each entity getter has a **plural** sibling — `get_tracks`, `get_albums`,
+`get_artists`, `get_playlists`, `get_episodes`, `get_shows` — that fetches many
+inputs in one call and returns one [`BatchItem`](#batchitem) per input, **index-
+aligned** with what you passed in.
+
+```python
+from spotify_scraper import SpotifyClient
+
+with SpotifyClient() as client:
+    items = client.get_tracks([
+        "4uLU6hMCjMI75M1A2tKUQC",
+        "spotify:track:0VjIjW4GlUZAMYd2vXMi3b",
+        "this-is-not-valid",
+    ])
+
+for item in items:
+    if item.ok:
+        print(item.result.name)
+    else:
+        print("failed:", item.value, "->", item.error)
+```
+
+## Partial failure never aborts the batch
+
+A single dead or malformed input does **not** raise or stop the others — its
+outcome is captured on that one `BatchItem` instead. Exactly one of `result` /
+`error` is populated, and the input `value` is echoed back so you can correlate
+outcomes even after deduplication or reordering:
+
+- `item.ok` — `True` when the fetch succeeded;
+- `item.result` — the typed model on success, else `None`;
+- `item.error` — the captured `SpotifyScraperError` on failure, else `None`;
+- `item.unwrap()` — returns the model, or re-raises the captured error.
+
+```python
+ok = [i.result for i in items if i.ok]
+failed = {i.value: i.error for i in items if not i.ok}
+```
+
+## Async + managed concurrency
+
+The async client runs batch fetches **concurrently**, bounded by the client's
+`max_concurrency` (default `5`) so it never floods Spotify; the per-host rate
+limiter still governs request pacing on top of that.
+
+```python
+from spotify_scraper import AsyncSpotifyClient
+
+async with AsyncSpotifyClient(max_concurrency=8) as client:
+    items = await client.get_tracks([id1, id2, id3, ...])
+```
+
+The sync helpers fetch sequentially. Both return the same `BatchItem` shape.
+
+## `BatchItem`
+
+::: spotify_scraper.batch.BatchItem

--- a/docs/index.md
+++ b/docs/index.md
@@ -140,7 +140,8 @@ anti-ban resilience, the browser fallback — plus the command-line interface.
 |---|---|
 | 3.0.0 | Core library. |
 | 3.1.0 | The command-line interface. |
-| 3.2.0 | Cookie-authenticated **lyrics** extraction (this release). |
+| 3.2.0 | Cookie-authenticated **lyrics** extraction. |
+| 3.5 | **Batch helpers** (`get_*s([...])`) with managed concurrency. |
 
 ### Planned
 
@@ -151,7 +152,7 @@ Upcoming work is tracked in the GitHub
 |---|---|
 | 3.3 | Podcast [transcripts](https://github.com/AliAkhtari78/SpotifyScraper/issues/127) and first-class [authenticated sessions](https://github.com/AliAkhtari78/SpotifyScraper/issues/128) — browser-assisted login with a persistent cookie store (no stored passwords). |
 | 3.4 | [Search](https://github.com/AliAkhtari78/SpotifyScraper/issues/129) across every entity type and [market / region](https://github.com/AliAkhtari78/SpotifyScraper/issues/130) support. |
-| 3.5 | Optional [response caching](https://github.com/AliAkhtari78/SpotifyScraper/issues/131) and [batch helpers](https://github.com/AliAkhtari78/SpotifyScraper/issues/132) with managed concurrency. |
+| 3.5 | Optional [response caching](https://github.com/AliAkhtari78/SpotifyScraper/issues/131). |
 
 Scope is subject to change — 👍 the issues that matter most to you.
 
@@ -159,6 +160,11 @@ Scope is subject to change — 👍 the issues that matter most to you.
     Cookie-authenticated **lyrics** extraction has shipped:
     `client.get_lyrics(track)` and the `spotifyscraper lyrics` command. See the
     [Lyrics & cookies guide](guides/lyrics-and-cookies.md).
+
+!!! success "Batch helpers have shipped"
+    Plural `client.get_tracks([...])` / `get_albums([...])` / … return one
+    partial-failure-safe `BatchItem` per input; the async client bounds
+    concurrency with `max_concurrency`. See the [batch guide](guides/batch.md).
 
 !!! warning "Legal & terms of service"
     SpotifyScraper is intended for **personal, educational, and research use**.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
     - CLI: guides/cli.md
     - Lyrics & cookies: guides/lyrics-and-cookies.md
     - Async: guides/async.md
+    - Batch helpers: guides/batch.md
     - Media downloads: guides/media-downloads.md
     - Anti-ban & resilience: guides/anti-ban.md
     - Browser fallback: guides/browser-fallback.md

--- a/openspec/changes/add-batch-helpers/.openspec.yaml
+++ b/openspec/changes/add-batch-helpers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-14

--- a/openspec/changes/add-batch-helpers/design.md
+++ b/openspec/changes/add-batch-helpers/design.md
@@ -1,0 +1,178 @@
+# Design: add-batch-helpers
+
+## Context
+
+Issue #132. The single-entity getters already route every request through the
+per-host `TokenBucket` (`http/ratelimit.py`), so the throttling primitive exists.
+What is missing is a batch-granularity surface that (a) does not let one bad ID
+kill the run and (b) on async, does not fan out unboundedly. This is pure
+ergonomics: no new endpoint, no new dependency, no parser/model/transport change.
+
+## Goals / Non-goals
+
+- **Goal:** plural `get_*s(values)` on both clients with identical signatures,
+  ordered per-item results, captured partial failures, and bounded async
+  concurrency that composes with the rate limiter.
+- **Non-goal:** batching authenticated features (`get_lyrics`, and any future
+  transcript) — they are cookie-gated and a different failure/auth story
+  (see Open Questions). No retry/backoff changes (the existing `RetryPolicy`
+  already governs each request). No streaming/async-iterator API.
+
+## Decision 1 — Partial-failure model: `BatchItem[_T]` (the load-bearing choice)
+
+A batch over real-world IDs WILL contain dead/region-locked entries
+(`NotFoundError`) and typos (`URLError`). Raising on the first one is useless for
+bulk work. The chosen model is a frozen, slotted, **generic** result wrapper in a
+new sans-io module `src/spotify_scraper/batch.py`:
+
+```python
+@dataclass(frozen=True, slots=True)
+class BatchItem(Generic[_T]):
+    value: str                      # the input, echoed back
+    result: _T | None = None        # model on success
+    error: Exception | None = None  # captured SpotifyScraperError on failure
+
+    @property
+    def ok(self) -> bool: ...
+    def unwrap(self) -> _T: ...      # model or re-raise
+```
+
+**Why this over alternatives:**
+
+- *Raise-on-first-error* — rejected: defeats the purpose of a batch.
+- *`return_exceptions=True` raw list of `model | Exception`* — rejected: untyped
+  union, loses which input produced which result once values are deduped/reordered
+  in user code, and forces `isinstance` checks everywhere. `BatchItem` echoes
+  `value` and is typed `Sequence[BatchItem[Track]]`.
+- *Separate `(results, errors)` tuple* — rejected: loses input order alignment
+  and forces callers to re-correlate.
+- *A `BatchResult` collection wrapper with `.ok`/`.errors` helpers* — deferred:
+  `Sequence[BatchItem[_T]]` already gives ordering + per-item outcome and is the
+  minimal honest type; a convenience collection can be layered later without a
+  breaking change (it would wrap the same items).
+
+`unwrap()` gives the "simple list when all succeed" ergonomic the prompt asks for:
+`[item.unwrap() for item in client.get_tracks(ids)]` raises on the first failure
+if the caller wants all-or-nothing, or they inspect `.ok` for graceful handling.
+
+**Capture boundary = `SpotifyScraperError`.** This is the base of every
+library error (`errors.py`): `NotFoundError`, `URLError`, `NetworkError`/
+`RateLimitedError`, `ParsingError`, `TokenError`, `AuthenticationError`,
+`MediaError`. Catching exactly this base means library failures are captured per
+item while real bugs, `KeyboardInterrupt`, and `asyncio.CancelledError` (none of
+which subclass `SpotifyScraperError`) propagate and abort the batch — the correct
+behavior for cancellation and programming errors. The field is typed `Exception |
+None` (honest about what a dataclass field could hold) even though only
+`SpotifyScraperError` is ever stored.
+
+`BatchItem` is a control wrapper, not Spotify data, so it carries **no
+`to_dict()`** — CLAUDE.md's JSON-safe rule targets entity models.
+
+## Decision 2 — `max_concurrency` is a constructor arg, not a method param (Option A)
+
+`tests/unit/test_parity.py::test_data_methods_share_signatures` compares
+`list(signature.parameters)` and the `return_annotation` string for every shared
+public method. If `max_concurrency` were a method parameter, it would have to
+appear (inertly) on the sync helpers too, or parity breaks.
+
+**Chosen: Option A** — `max_concurrency: int = 5` on `AsyncSpotifyClient.__init__`
+only; it builds and stores a single `asyncio.Semaphore`. The sync client has no
+such concept (it is sequential). The six plural signatures stay byte-identical
+across clients, so parity passes with **no test change**.
+
+*Option B* (per-call `*, max_concurrency: int = 8` on both, a no-op on sync) was
+rejected: it adds a dead parameter to the entire sync API surface just to satisfy
+the signature comparison. Construction-time configuration matches the existing
+pattern (`rate_limit`, `retry`, `host_rate_limits` are all constructor-set).
+
+Default `5` deliberately equals the default `RateLimit.burst=5`, so concurrency
+never structurally exceeds burst capacity; the bucket remains the rate limiter and
+the semaphore the fan-out limiter, and the two compose without one masking the
+other. `max_concurrency >= 1` is validated in `__init__` (mirroring
+`RateLimit.__post_init__`).
+
+## Decision 3 — Sync sequential, async semaphore-bounded `gather`
+
+**Sync** (`_sync/client.py`):
+
+```python
+def _batch(self, values, fetch):
+    self._ensure_open()                       # fail fast if closed
+    out = []
+    for value in values:
+        try:    out.append(BatchItem(value, result=fetch(value)))
+        except SpotifyScraperError as exc:
+                out.append(BatchItem(value, error=exc))
+    return out
+```
+
+No threads, no semaphore: each `fetch(value)` (a single-entity getter) routes
+every underlying request through the same per-host `TokenBucket`, so a sequential
+loop is already rate-limited. Each inner getter also re-checks `_ensure_open` via
+`_resolve`, so a mid-batch `close()` is still safe; the up-front check just fails
+fast on an already-closed client.
+
+**Async** (`_async/client.py`):
+
+```python
+async def _batch(self, values, fetch):
+    self._ensure_open()
+    async def one(value):
+        async with self._semaphore:           # bounded fan-out
+            try:    return BatchItem(value, result=await fetch(value))
+            except SpotifyScraperError as exc:
+                    return BatchItem(value, error=exc)
+    return list(await asyncio.gather(*(one(v) for v in values)))
+```
+
+- `asyncio.Semaphore(max_concurrency)` caps concurrent entity pipelines →
+  bounds open sockets and bucket-lock contention. The `AsyncTokenBucket` still
+  enforces request *rate* underneath. Semaphore = concurrency, bucket = rate;
+  they compose.
+- `gather` with default `return_exceptions=False`: every task catches its own
+  `SpotifyScraperError`, so `gather` never sees a library exception. A non-library
+  escape (a bug) cancels siblings and re-raises — correct. `CancelledError` is not
+  a `SpotifyScraperError`, so it is never swallowed.
+- `gather` returns positionally → results are index-aligned with `values`,
+  matching the sync contract for free.
+- A single shared per-client semaphore bounds concurrency **across overlapping
+  batch calls** too, which is what you want for one IP. (Per-call isolation was
+  considered and rejected as surprising — a second concurrent batch could double
+  the real fan-out.)
+
+`_semaphore` is added to the async client's `__slots__`.
+
+The plural getters are six thin wrappers each delegating to `_batch` with the
+matching single-entity getter (or a `lambda` forwarding the `max_tracks`/
+`max_episodes` cap).
+
+## Types / mypy --strict
+
+- `BatchItem(Generic[_T])`; helpers return `Sequence[BatchItem[Track]]` etc.
+- `fetch` is `Callable[[str], _T]` (sync) / `Callable[[str], Awaitable[_T]]`
+  (async). Reuse the module-level `_T = TypeVar("_T")` already present in both
+  clients; declare a local `_T` in `batch.py`.
+- New imports: `Sequence` (both), `Awaitable` + `import asyncio` (async),
+  `from spotify_scraper.batch import BatchItem` (both), `BatchItem` export in the
+  package `__init__`.
+
+## Testing strategy (hermetic)
+
+- Reuse the respx + fixture harness from `test_client_entities*.py` for happy
+  path, partial failure (one ID → 404 → captured `NotFoundError`, order
+  preserved, no raise), `URLError` item, closed-client fail-fast, and cap
+  forwarding.
+- Async-only bounded-concurrency test uses a **recording stub `AsyncTransport`**
+  (the `_AsyncStubTransport` pattern from `tests/unit/http/test_cache.py`):
+  increment an in-flight counter on `get` entry, coordinate overlap with an
+  `asyncio.Event`/barrier (no real sleeps → deterministic), record max in-flight,
+  assert `1 < max <= max_concurrency`.
+- `test_parity.py` runs unchanged and must stay green (Option A guarantees it).
+
+## Risks
+
+- **Memory:** all `BatchItem`s are held until the batch completes (no streaming).
+  Acceptable for the convenience use case; an async-iterator variant is a future,
+  non-breaking addition.
+- **Shared semaphore semantics:** overlapping batches share one budget. Documented
+  as intentional (one IP, one fan-out budget).

--- a/openspec/changes/add-batch-helpers/proposal.md
+++ b/openspec/changes/add-batch-helpers/proposal.md
@@ -1,0 +1,103 @@
+# Proposal: add-batch-helpers
+
+> **Status: targets v3.x.** Closes issue #132. Adds six **plural convenience
+> helpers** (`get_tracks`, `get_albums`, `get_artists`, `get_playlists`,
+> `get_episodes`, `get_shows`) to **both** client facades so callers can fetch
+> many IDs in one call without hand-rolling throttling. **Pure ergonomics** — no
+> new endpoint, no new runtime dependency, no parser/model/transport change. The
+> existing per-host `TokenBucket` already throttles every request, so SYNC is a
+> simple ordered loop; ASYNC is `asyncio.gather` bounded by a constructor-set
+> `asyncio.Semaphore` so it never opens too many sockets or outruns the rate
+> limiter. Partial failures are captured per item in a new pure, frozen/slotted,
+> generic `BatchItem[_T]` result — a 404 on one ID never kills the batch.
+> Fully hermetic to test (respx + a recording stub transport); no live step.
+
+## Why
+
+Users routinely have a list of IDs/URLs (a column in a CSV, a set of artist URIs,
+a playlist's worth of track links) and want all of them. Today they must write
+their own loop and — to avoid bans — their own throttling and their own
+try/except per item. That is exactly the boilerplate the library should own: the
+single-entity getters already pass every underlying request through the
+per-host `TokenBucket` (`ratelimit.py`), so the throttling primitive exists; it
+just is not exposed at batch granularity.
+
+Two things make a naive `[client.get_track(v) for v in values]` (sync) or
+`asyncio.gather(*(client.get_track(v) ...))` (async) wrong:
+
+1. **One bad ID kills the batch.** A single `NotFoundError` (dead/region-locked
+   ID) or `URLError` (typo) aborts the whole loop / fails the whole `gather`.
+   A batch over mixed real-world IDs *must* return per-item outcomes.
+2. **Unbounded async fan-out.** `get_album`/`get_show`/`get_playlist` each issue
+   an embed fetch plus 1..N pathfinder pages. Firing all N entities into one
+   `gather` schedules a huge number of in-flight coroutines all contending on the
+   bucket lock and all holding `httpx.AsyncClient` connections — unbounded socket
+   and memory pressure. The `AsyncTokenBucket` caps the *rate*; nothing caps the
+   *fan-out width*.
+
+So: add plural helpers that (a) capture `SpotifyScraperError` per item into an
+ordered, typed result and (b) bound async concurrency with a semaphore that
+composes cleanly with the rate limiter (semaphore = concurrency limiter, bucket =
+rate limiter).
+
+## What Changes
+
+- **`src/spotify_scraper/batch.py`** (new, **sans-io**, zero I/O, stdlib only):
+  a `BatchItem[_T]` frozen slotted generic dataclass — the load-bearing
+  partial-failure type. Fields `value: str` (the input, echoed back), `result: _T
+  | None`, `error: Exception | None`; properties `.ok` and `.unwrap()`
+  (returns the model or re-raises the captured error). This is a *control
+  wrapper*, not Spotify data, so it needs no `to_dict()` (CLAUDE.md's JSON-safe
+  rule applies to entity models).
+- **`_sync/client.py`** — a private `_batch(values, fetch)` engine (ordered
+  sequential loop; one up-front `_ensure_open()`; capture only
+  `SpotifyScraperError` per item) plus six thin plural getters delegating to it.
+  No threads, no semaphore: the per-host `TokenBucket` in the transport already
+  throttles each underlying call, so sequential **is** rate-limited.
+- **`_async/client.py`** — a `max_concurrency: int = 5` constructor kwarg
+  (**async client only**), a `_semaphore` slot holding an
+  `asyncio.Semaphore(max_concurrency)`, an `async def _batch(values, fetch)`
+  engine running `asyncio.gather` over per-item coroutines each gated by that
+  semaphore (order preserved by `gather`; capture only `SpotifyScraperError`
+  inside each task so `CancelledError`/bugs propagate), plus the six plural
+  getters. `_semaphore` is added to `__slots__`.
+- **Critical parity decision (Option A): `max_concurrency` is a constructor arg
+  on the async client, NOT a method parameter.** `test_parity.py` compares
+  `list(signature.parameters)` and the `return_annotation` string for every
+  shared public method. Keeping `max_concurrency` off the method signatures means
+  the six plural helpers have **byte-identical** signatures across sync/async, so
+  parity passes trivially. Default `5` matches `RateLimit.burst=5` so concurrency
+  never structurally outruns burst capacity.
+- **Plural signatures (identical on both clients, only `async`/`await` differs):**
+  - `get_tracks(self, values: Sequence[str]) -> Sequence[BatchItem[Track]]`
+  - `get_albums(self, values: Sequence[str]) -> Sequence[BatchItem[Album]]`
+  - `get_artists(self, values: Sequence[str]) -> Sequence[BatchItem[Artist]]`
+  - `get_episodes(self, values: Sequence[str]) -> Sequence[BatchItem[Episode]]`
+  - `get_playlists(self, values: Sequence[str], *, max_tracks: int | None = 100) -> Sequence[BatchItem[Playlist]]`
+  - `get_shows(self, values: Sequence[str], *, max_episodes: int | None = 50) -> Sequence[BatchItem[Show]]`
+  The `max_tracks`/`max_episodes` caps forward to the underlying singular getter.
+- **Exports:** `BatchItem` added to `src/spotify_scraper/__init__.py` imports and
+  `__all__` (kept alphabetized). The six instance methods are auto-public.
+- **Hermetic tests** mirroring the respx/fixture harness in
+  `tests/unit/test_client_entities*.py`: happy path (ordered `ok` items), partial
+  failure (one ID 404 → that item's `.error` is `NotFoundError`, batch does not
+  raise, order preserved), `URLError` item (malformed input captured, batch
+  continues), closed-client raises up front, cap forwarding, and — async only —
+  a recording stub transport asserting in-flight `get` calls never exceed
+  `max_concurrency` while still proving `>1` runs concurrently.
+
+## Impact
+
+- **New:** `src/spotify_scraper/batch.py`,
+  `tests/unit/test_client_batch.py`, `tests/unit/test_client_batch_async.py`.
+- **Edited:** `src/spotify_scraper/_sync/client.py` (imports + `_batch` + 6
+  getters), `src/spotify_scraper/_async/client.py` (imports + `max_concurrency`
+  ctor arg + `_semaphore` slot + `_batch` + 6 getters),
+  `src/spotify_scraper/__init__.py` (export `BatchItem`).
+- **No changes** to `transport.py`, `ratelimit.py`, `retry.py`, `pathfinder.py`,
+  `urls.py`, `errors.py`, `auth/*`, `api/*`, `media/*`, or any model. The helpers
+  only orchestrate existing I/O methods.
+- **Default behavior unchanged:** existing single-entity getters are untouched.
+  `test_parity.py` passes unchanged (Option A keeps signatures identical). One new
+  runtime dependency: **none** (`asyncio`, `dataclasses`, `collections.abc` are
+  stdlib).

--- a/openspec/changes/add-batch-helpers/specs/batch-helpers/spec.md
+++ b/openspec/changes/add-batch-helpers/specs/batch-helpers/spec.md
@@ -1,0 +1,124 @@
+# batch-helpers
+
+## ADDED Requirements
+
+### Requirement: Plural convenience helpers on both clients
+
+Both `SpotifyClient` and `AsyncSpotifyClient` SHALL provide six plural helpers —
+`get_tracks`, `get_albums`, `get_artists`, `get_playlists`, `get_episodes`,
+`get_shows` — that accept a `Sequence[str]` of URLs/URIs/IDs and apply the
+client's configured rate limiting (and, on async, bounded concurrency) across all
+inputs. The helpers SHALL add **no new endpoint and no new runtime dependency**;
+they SHALL only orchestrate the existing single-entity getters.
+
+#### Scenario: Many tracks in one call
+
+- **WHEN** `client.get_tracks([id1, id2, id3])` is called with three valid IDs
+- **THEN** three results are returned, each carrying the fetched `Track`, with no
+  caller-written loop or throttling
+
+#### Scenario: Pagination caps forward
+
+- **WHEN** `get_playlists(values, max_tracks=25)` or
+  `get_shows(values, max_episodes=10)` is called
+- **THEN** each underlying `get_playlist`/`get_show` receives that cap
+
+### Requirement: Sync/async signature parity
+
+The six plural helpers SHALL have **byte-identical** public signatures across the
+sync and async clients — identical parameter names, order, defaults, and
+return-annotation text — differing only by `async def`/`await`. The
+async-only concurrency control SHALL therefore be a **constructor argument**, not
+a method parameter, so the parity test (`tests/unit/test_parity.py`) passes
+without modification.
+
+#### Scenario: Parity test stays green
+
+- **WHEN** `test_data_methods_share_signatures` inspects the six plural helpers
+- **THEN** `list(signature.parameters)` and the return annotation match between
+  `SpotifyClient` and `AsyncSpotifyClient` for every one
+
+#### Scenario: Concurrency is set at construction, not per call
+
+- **WHEN** a caller wants to bound async concurrency
+- **THEN** they pass `AsyncSpotifyClient(max_concurrency=N)`; no plural method
+  accepts a `max_concurrency` argument on either client
+
+### Requirement: Typed, ordered, per-item partial-failure result
+
+Each plural helper SHALL return an ordered `Sequence[BatchItem[_T]]`,
+index-aligned with the input sequence. `BatchItem` SHALL be a frozen, slotted,
+generic dataclass carrying the echoed input `value`, a `result` (the model on
+success) XOR an `error` (the captured exception on failure), an `ok` property,
+and an `unwrap()` method that returns the model or re-raises the captured error.
+A per-item failure SHALL NOT abort the batch.
+
+#### Scenario: A 404 on one ID does not kill the batch
+
+- **WHEN** one ID in `get_tracks([good, dead])` does not exist
+- **THEN** the helper returns both items in input order; the dead item's `ok` is
+  `False` and its `error` is a `NotFoundError`; the good item's `ok` is `True`;
+  the call itself does not raise
+
+#### Scenario: Invalid input is captured, not raised
+
+- **WHEN** a malformed value (failing `urls.parse`) is included
+- **THEN** its item carries a `URLError` in `error`, `ok` is `False`, and the
+  remaining valid inputs are still fetched
+
+#### Scenario: Ordered and index-aligned
+
+- **WHEN** any plural helper returns
+- **THEN** result `i` corresponds to input `i` for every index, on both clients
+
+#### Scenario: unwrap re-raises the captured error
+
+- **WHEN** `item.unwrap()` is called on a failed item
+- **THEN** it re-raises the captured exception; on a successful item it returns
+  the model
+
+### Requirement: Capture boundary is the library error base
+
+The plural helpers SHALL capture **only** `SpotifyScraperError` (and subclasses)
+per item. Any non-library exception — including programming bugs,
+`KeyboardInterrupt`, and `asyncio.CancelledError` — SHALL propagate and abort the
+batch, so cancellation and real bugs are never silently swallowed.
+
+#### Scenario: CancelledError propagates
+
+- **WHEN** an in-flight async batch task is cancelled
+- **THEN** the cancellation is not captured as a `BatchItem.error`; it propagates
+
+#### Scenario: Closed client fails fast
+
+- **WHEN** a plural helper is called on a closed client
+- **THEN** it raises `SpotifyScraperError` up front, before fetching any item
+
+### Requirement: Sync is sequential; async is bounded-concurrent
+
+The sync helpers SHALL fetch sequentially on one thread; the per-host
+`TokenBucket` already throttles each underlying request, so no additional
+throttling is added. The async helpers SHALL run `asyncio.gather` over per-item
+coroutines, each gated by a single per-client `asyncio.Semaphore(max_concurrency)`
+(default a small safe value, e.g. 5), so the number of concurrent entity
+pipelines — and thus open sockets and bucket-lock contention — is bounded while
+the rate limiter still governs request rate.
+
+#### Scenario: Async never exceeds max_concurrency
+
+- **WHEN** `get_tracks` runs over many IDs on a client built with
+  `max_concurrency=N`
+- **THEN** the number of simultaneously in-flight entity fetches never exceeds
+  `N`, while more than one runs concurrently (the semaphore bounds but does not
+  serialize)
+
+#### Scenario: Sync needs no extra throttling
+
+- **WHEN** a sync plural helper runs over many IDs
+- **THEN** each underlying request passes through the same per-host token bucket,
+  so the batch is already rate-limited without threads or a semaphore
+
+#### Scenario: max_concurrency is validated
+
+- **WHEN** `AsyncSpotifyClient(max_concurrency=0)` is constructed
+- **THEN** a `ValueError` is raised

--- a/openspec/changes/add-batch-helpers/tasks.md
+++ b/openspec/changes/add-batch-helpers/tasks.md
@@ -1,0 +1,164 @@
+# Tasks: add-batch-helpers
+
+## 0. Ground the design (read-only audit — no code yet)
+
+- [ ] 0.1 Confirm `_T = TypeVar("_T")` already exists at module level in BOTH
+      `_sync/client.py` (line 49) and `_async/client.py` (line 48) — reuse it for
+      the `_batch` engines; do not redeclare.
+- [ ] 0.2 Confirm `test_parity.py` compares `list(signature.parameters)` AND the
+      `return_annotation` string for every shared public method (lines 26-32).
+      This pins Option A: `max_concurrency` MUST NOT be a method parameter.
+- [ ] 0.3 Confirm `SpotifyScraperError` is the base of every per-item failure
+      (`NotFoundError`, `URLError`, `NetworkError`/`RateLimitedError`,
+      `ParsingError`, `TokenError`, `AuthenticationError`, `MediaError`) in
+      `errors.py` — it is the single catch boundary.
+- [ ] 0.4 Confirm `urls.parse` (called inside `_resolve`) raises `URLError`
+      BEFORE any I/O, so a malformed input is captured per item like any other
+      `SpotifyScraperError`.
+
+## 1. The sans-io result type (frozen, slotted, generic)
+
+- [ ] 1.1 Create `src/spotify_scraper/batch.py` with module docstring, `from
+      __future__ import annotations`, `from collections.abc import Sequence`,
+      `from dataclasses import dataclass`, `from typing import Generic, TypeVar`.
+      Declare a local `_T = TypeVar("_T")`.
+- [ ] 1.2 Add `@dataclass(frozen=True, slots=True) class BatchItem(Generic[_T])`
+      with `value: str`, `result: _T | None = None`,
+      `error: Exception | None = None`. Type `error` as `Exception` (not
+      `SpotifyScraperError`) to stay honest about the field, while the engines
+      capture only `SpotifyScraperError`.
+- [ ] 1.3 Add `@property def ok(self) -> bool: return self.error is None`.
+- [ ] 1.4 Add `def unwrap(self) -> _T:` — `if self.error is not None: raise
+      self.error`; `assert self.result is not None`; `return self.result`.
+      Docstring: returns the model on success, re-raises the captured error
+      otherwise.
+- [ ] 1.5 (Optional, only if symmetry is wanted) no `to_dict()` — `BatchItem` is
+      a control wrapper, not Spotify data. Document this choice in the docstring.
+
+## 2. Exports
+
+- [ ] 2.1 In `src/spotify_scraper/__init__.py` add `from spotify_scraper.batch
+      import BatchItem` and insert `"BatchItem"` into `__all__` keeping it
+      alphabetized (between `"Artist"`/`"ArtistRef"` group and
+      `"AsyncCachingTransport"` — i.e. after `"ArtistRef"`).
+
+## 3. SYNC plural helpers (sequential — already rate-limited)
+
+- [ ] 3.1 In `_sync/client.py` add imports: `from collections.abc import
+      Sequence` (extend the existing `from collections.abc import Callable,
+      Mapping` line) and `from spotify_scraper.batch import BatchItem`.
+- [ ] 3.2 Add private engine `def _batch(self, values: Sequence[str], fetch:
+      Callable[[str], _T]) -> Sequence[BatchItem[_T]]`: call `self._ensure_open()`
+      once up front; iterate `values` IN ORDER; per item `try:
+      out.append(BatchItem(value, result=fetch(value)))` / `except
+      SpotifyScraperError as exc: out.append(BatchItem(value, error=exc))`;
+      return the list. Catch ONLY `SpotifyScraperError`.
+- [ ] 3.3 `def get_tracks(self, values: Sequence[str]) -> Sequence[BatchItem[Track]]:
+      return self._batch(values, self.get_track)`.
+- [ ] 3.4 `get_albums` → `self._batch(values, self.get_album)`;
+      `get_artists` → `self._batch(values, self.get_artist)`;
+      `get_episodes` → `self._batch(values, self.get_episode)`.
+- [ ] 3.5 `def get_playlists(self, values: Sequence[str], *, max_tracks: int |
+      None = 100) -> Sequence[BatchItem[Playlist]]: return self._batch(values,
+      lambda v: self.get_playlist(v, max_tracks=max_tracks))`.
+- [ ] 3.6 `def get_shows(self, values: Sequence[str], *, max_episodes: int | None
+      = 50) -> Sequence[BatchItem[Show]]: return self._batch(values, lambda v:
+      self.get_show(v, max_episodes=max_episodes))`.
+- [ ] 3.7 Add a docstring to each plural getter (Returns: an ordered Sequence of
+      `BatchItem`, index-aligned with `values`; per-item `SpotifyScraperError` is
+      captured, never raised mid-batch; Raises `SpotifyScraperError` only if the
+      client is already closed).
+
+## 4. ASYNC plural helpers (bounded asyncio.gather)
+
+- [ ] 4.1 In `_async/client.py` add imports: extend `from collections.abc import
+      Callable, Mapping` to also import `Awaitable, Sequence`; add `import asyncio`;
+      add `from spotify_scraper.batch import BatchItem`.
+- [ ] 4.2 Add `"_semaphore"` to `AsyncSpotifyClient.__slots__` (keep sorted).
+- [ ] 4.3 Add `max_concurrency: int = 5` as a keyword-only param to
+      `__init__` (place it among the existing keyword-only args, e.g. after
+      `cache`). Validate `max_concurrency >= 1` (raise `ValueError` otherwise,
+      mirroring `RateLimit.__post_init__` style). Store
+      `self._semaphore = asyncio.Semaphore(max_concurrency)`.
+- [ ] 4.4 Document `max_concurrency` in the `__init__` docstring: caps how many
+      entity pipelines run concurrently in the plural `get_*s` helpers; bounds
+      open sockets and bucket-lock contention; the rate limiter still governs
+      request rate. Default 5 matches the default `RateLimit.burst`.
+- [ ] 4.5 Add `async def _batch(self, values: Sequence[str], fetch:
+      Callable[[str], Awaitable[_T]]) -> Sequence[BatchItem[_T]]`: call
+      `self._ensure_open()`; define an inner `async def one(value: str) ->
+      BatchItem[_T]` that does `async with self._semaphore:` then `try: return
+      BatchItem(value, result=await fetch(value))` / `except SpotifyScraperError
+      as exc: return BatchItem(value, error=exc)`; `return list(await
+      asyncio.gather(*(one(v) for v in values)))`. Use default
+      `return_exceptions=False` — every task catches its own library error, so
+      `gather` never sees one; `CancelledError` (not a `SpotifyScraperError`)
+      propagates correctly.
+- [ ] 4.6 Add the six async plural getters mirroring 3.3-3.6 with `async def` +
+      `await self._batch(...)` and BYTE-IDENTICAL signatures to the sync side
+      (same param names, order, defaults, return annotation text).
+- [ ] 4.7 Copy the sync plural docstrings verbatim (the behavioral contract is
+      identical; only execution model differs).
+
+## 5. Parity guard
+
+- [ ] 5.1 Run `tests/unit/test_parity.py` — the existing
+      `test_public_method_sets_match_modulo_lifecycle` now also covers the six new
+      methods (must match) and `test_data_methods_share_signatures` asserts
+      identical params + return annotation. Confirm GREEN. If it fails on a
+      `values` vs `values, max_concurrency` mismatch, `max_concurrency` leaked
+      onto a method signature — remove it (Option A).
+
+## 6. Hermetic tests (no live step)
+
+- [ ] 6.1 `tests/unit/test_client_batch.py` (sync): reuse the respx + fixture
+      harness from `test_client_entities.py` (fixtures under
+      `tests/fixtures/embed/` + `tests/fixtures/pathfinder/`, the `IDS` map, the
+      `_embed_html`/`_mock` helpers, `PATHFINDER_RE`).
+- [ ] 6.2 **Happy path:** `get_tracks([id, id])` → two items, both `.ok`, in input
+      order, each `.result` is a `Track`.
+- [ ] 6.3 **Partial failure:** mock one track's embed (or pathfinder) to a 404 so
+      the inner getter raises `NotFoundError`; assert that item's `.ok is False`
+      and `isinstance(item.error, NotFoundError)`, the other item is `.ok`, ORDER
+      is preserved, and `get_tracks` itself did NOT raise. Assert
+      `item.unwrap()` re-raises `NotFoundError` for the failed item.
+- [ ] 6.4 **URLError item:** pass a malformed value (e.g. `"not-a-spotify-id"`)
+      alongside a good one; assert the bad item's `.error` is a `URLError`, the
+      good item is `.ok`, batch continues.
+- [ ] 6.5 **Closed client:** `client.close()` then `client.get_tracks([id])`
+      raises `SpotifyScraperError` up front (via the engine's `_ensure_open`).
+- [ ] 6.6 **Cap forwarding:** `get_playlists(values, max_tracks=N)` and
+      `get_shows(values, max_episodes=N)` — assert the underlying getter received
+      the cap (e.g. via a respx route-count assertion or a parsed-result length
+      bound, matching how the singular cap tests already assert).
+- [ ] 6.7 `tests/unit/test_client_batch_async.py` (async): mirror 6.2-6.6 with
+      `await`, `AsyncSpotifyClient`, and the async respx harness from
+      `test_client_entities_async.py`.
+- [ ] 6.8 **Async bounded-concurrency (async-only):** inject a recording
+      `AsyncTransport` stub (pattern from `tests/unit/http/test_cache.py`'s
+      `_AsyncStubTransport`) that increments an in-flight counter on entry to
+      `get`, `await asyncio.sleep(0)`/a small event to overlap, decrements on
+      exit, and records the max observed in-flight. Build
+      `AsyncSpotifyClient(transport=stub, max_concurrency=2)`, run
+      `get_tracks([...8 ids...])`, assert observed max in-flight `<=
+      max_concurrency` AND `> 1` (proves the semaphore neither over-runs nor
+      serializes). Keep it deterministic with an `asyncio.Event`/barrier, no real
+      sleeps.
+- [ ] 6.9 **max_concurrency validation:** `AsyncSpotifyClient(max_concurrency=0)`
+      raises `ValueError`.
+
+## 7. Quality gates
+
+- [ ] 7.1 `make type` (mypy --strict) clean — `BatchItem` generic resolves
+      (`Sequence[BatchItem[Track]]` etc.); `fetch` callbacks typed
+      `Callable[[str], _T]` (sync) / `Callable[[str], Awaitable[_T]]` (async);
+      no `Any` leakage.
+- [ ] 7.2 `make lint` / `make format` clean.
+- [ ] 7.3 `make test` green (including `test_parity.py`).
+- [ ] 7.4 `make cov` stays above the 85% floor; `batch.py` and both engines
+      well-covered (happy, partial-fail, URLError, closed, bounded-concurrency).
+- [ ] 7.5 Confirm no new runtime dependency in `pyproject.toml` (stdlib
+      `asyncio`, `dataclasses`, `collections.abc`, `typing` only).
+- [ ] 7.6 (Docs, optional but recommended) add a short "Batch fetching" snippet to
+      the docs/usage page showing `BatchItem.ok`/`.unwrap()` and the async
+      `max_concurrency` knob.

--- a/openspec/changes/add-batch-helpers/tasks.md
+++ b/openspec/changes/add-batch-helpers/tasks.md
@@ -162,3 +162,13 @@
 - [ ] 7.6 (Docs, optional but recommended) add a short "Batch fetching" snippet to
       the docs/usage page showing `BatchItem.ok`/`.unwrap()` and the async
       `max_concurrency` knob.
+
+## 8. Review fixes
+
+- [x] 8.1 (code, prior session) bind the async batch semaphore per event loop so
+      a client reused across `asyncio.run()` no longer crashes; cross-loop
+      regression test added.
+- [x] 8.2 Docs: new `guides/batch.md` (plural helpers, partial-failure `BatchItem`,
+      async `max_concurrency`, `BatchItem` autodoc) + nav; README Batch section +
+      Features bullet + roadmap (3.5 batch shipped); index roadmap + success
+      admonition; CHANGELOG Unreleased.

--- a/src/spotify_scraper/__init__.py
+++ b/src/spotify_scraper/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from spotify_scraper._async import AsyncSpotifyClient
 from spotify_scraper._sync import SpotifyClient
+from spotify_scraper.batch import BatchItem
 from spotify_scraper.errors import (
     AuthenticationError,
     MediaError,
@@ -47,6 +48,7 @@ __all__ = [
     "ArtistRef",
     "AsyncSpotifyClient",
     "AuthenticationError",
+    "BatchItem",
     "Episode",
     "Image",
     "Lyrics",

--- a/src/spotify_scraper/_async/client.py
+++ b/src/spotify_scraper/_async/client.py
@@ -7,8 +7,9 @@ helpers, so the two facades stay thin and behaviourally identical.
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from collections.abc import Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from pathlib import Path
 from types import TracebackType
 from typing import Any, TypeVar
@@ -19,6 +20,7 @@ from spotify_scraper.api import parse_embed, parse_entities, pathfinder
 from spotify_scraper.api.parse_embed import EmbedSession
 from spotify_scraper.auth.anonymous import AsyncAnonymousTokenProvider
 from spotify_scraper.auth.cookies import AsyncCookieTokenProvider, load_sp_dc
+from spotify_scraper.batch import BatchItem
 from spotify_scraper.errors import (
     AuthenticationError,
     NetworkError,
@@ -60,6 +62,7 @@ class AsyncSpotifyClient:
         "_cookies",
         "_lyrics_tokens",
         "_owns_transport",
+        "_semaphore",
         "_tokens",
         "_transport",
     )
@@ -75,6 +78,7 @@ class AsyncSpotifyClient:
         transport: AsyncTransport | None = None,
         cookies: str | Path | Mapping[str, str] | None = None,
         host_rate_limits: Mapping[str, RateLimit] | None = None,
+        max_concurrency: int = 5,
     ) -> None:
         """Initialize the client.
 
@@ -91,7 +95,18 @@ class AsyncSpotifyClient:
                 stored now, consumed by the lyrics extraction change.
             host_rate_limits: Optional per-host rate overrides for the default
                 transport (e.g. to throttle ``api-partner.spotify.com``).
+            max_concurrency: Caps how many entity pipelines run concurrently in
+                the plural ``get_*s`` helpers; bounds open sockets and
+                bucket-lock contention while the rate limiter still governs
+                request rate. Must be at least 1. Defaults to 5, matching the
+                default :attr:`RateLimit.burst`.
+
+        Raises:
+            ValueError: If ``max_concurrency`` is less than 1.
         """
+        if max_concurrency < 1:
+            raise ValueError("max_concurrency must be at least 1")
+        self._semaphore = asyncio.Semaphore(max_concurrency)
         if transport is None:
             self._transport: AsyncTransport = AsyncHttpxTransport(
                 rate_limit=rate_limit,
@@ -294,6 +309,138 @@ class AsyncSpotifyClient:
         if not tier1:
             return show
         return await self._with_episodes(show, entity_id, session, max_episodes)
+
+    async def get_tracks(self, values: Sequence[str]) -> Sequence[BatchItem[Track]]:
+        """Fetch many tracks, one ordered :class:`BatchItem` per input.
+
+        Args:
+            values: Spotify track URLs, URIs, or 22-character IDs.
+
+        Returns:
+            An ordered sequence of :class:`BatchItem`, index-aligned with
+            ``values``; a per-item :class:`SpotifyScraperError` is captured in
+            ``error`` and never raised mid-batch.
+
+        Raises:
+            SpotifyScraperError: Only if the client is already closed.
+        """
+        return await self._batch(values, self.get_track)
+
+    async def get_albums(self, values: Sequence[str]) -> Sequence[BatchItem[Album]]:
+        """Fetch many albums, one ordered :class:`BatchItem` per input.
+
+        Args:
+            values: Spotify album URLs, URIs, or 22-character IDs.
+
+        Returns:
+            An ordered sequence of :class:`BatchItem`, index-aligned with
+            ``values``; a per-item :class:`SpotifyScraperError` is captured in
+            ``error`` and never raised mid-batch.
+
+        Raises:
+            SpotifyScraperError: Only if the client is already closed.
+        """
+        return await self._batch(values, self.get_album)
+
+    async def get_artists(self, values: Sequence[str]) -> Sequence[BatchItem[Artist]]:
+        """Fetch many artists, one ordered :class:`BatchItem` per input.
+
+        Args:
+            values: Spotify artist URLs, URIs, or 22-character IDs.
+
+        Returns:
+            An ordered sequence of :class:`BatchItem`, index-aligned with
+            ``values``; a per-item :class:`SpotifyScraperError` is captured in
+            ``error`` and never raised mid-batch.
+
+        Raises:
+            SpotifyScraperError: Only if the client is already closed.
+        """
+        return await self._batch(values, self.get_artist)
+
+    async def get_episodes(self, values: Sequence[str]) -> Sequence[BatchItem[Episode]]:
+        """Fetch many episodes, one ordered :class:`BatchItem` per input.
+
+        Args:
+            values: Spotify episode URLs, URIs, or 22-character IDs.
+
+        Returns:
+            An ordered sequence of :class:`BatchItem`, index-aligned with
+            ``values``; a per-item :class:`SpotifyScraperError` is captured in
+            ``error`` and never raised mid-batch.
+
+        Raises:
+            SpotifyScraperError: Only if the client is already closed.
+        """
+        return await self._batch(values, self.get_episode)
+
+    async def get_playlists(
+        self, values: Sequence[str], *, max_tracks: int | None = 100
+    ) -> Sequence[BatchItem[Playlist]]:
+        """Fetch many playlists, one ordered :class:`BatchItem` per input.
+
+        Args:
+            values: Spotify playlist URLs, URIs, or 22-character IDs.
+            max_tracks: Forwarded to each :meth:`get_playlist`; ``None`` fetches
+                all tracks.
+
+        Returns:
+            An ordered sequence of :class:`BatchItem`, index-aligned with
+            ``values``; a per-item :class:`SpotifyScraperError` is captured in
+            ``error`` and never raised mid-batch.
+
+        Raises:
+            SpotifyScraperError: Only if the client is already closed.
+        """
+        return await self._batch(
+            values, lambda value: self.get_playlist(value, max_tracks=max_tracks)
+        )
+
+    async def get_shows(
+        self, values: Sequence[str], *, max_episodes: int | None = 50
+    ) -> Sequence[BatchItem[Show]]:
+        """Fetch many shows, one ordered :class:`BatchItem` per input.
+
+        Args:
+            values: Spotify show URLs, URIs, or 22-character IDs.
+            max_episodes: Forwarded to each :meth:`get_show`; ``None`` fetches
+                all episodes.
+
+        Returns:
+            An ordered sequence of :class:`BatchItem`, index-aligned with
+            ``values``; a per-item :class:`SpotifyScraperError` is captured in
+            ``error`` and never raised mid-batch.
+
+        Raises:
+            SpotifyScraperError: Only if the client is already closed.
+        """
+        return await self._batch(
+            values, lambda value: self.get_show(value, max_episodes=max_episodes)
+        )
+
+    async def _batch(
+        self, values: Sequence[str], fetch: Callable[[str], Awaitable[_T]]
+    ) -> Sequence[BatchItem[_T]]:
+        """Fetch every value concurrently, bounded by ``max_concurrency``.
+
+        Each per-item coroutine is gated by the shared per-client semaphore, so
+        the number of in-flight entity pipelines never exceeds the configured
+        limit while the :class:`AsyncTokenBucket` still governs request rate.
+        Order is preserved by :func:`asyncio.gather`. Only
+        :class:`SpotifyScraperError` is captured per item; cancellation and
+        programming bugs are not subclasses, so they propagate and abort the
+        batch.
+        """
+        self._ensure_open()
+
+        async def one(value: str) -> BatchItem[_T]:
+            async with self._semaphore:
+                try:
+                    return BatchItem(value, result=await fetch(value))
+                except SpotifyScraperError as exc:
+                    return BatchItem(value, error=exc)
+
+        return list(await asyncio.gather(*(one(value) for value in values)))
 
     async def get_lyrics(self, value: str) -> Lyrics:
         """Fetch a track's lyrics using the cookie-derived web-player token.

--- a/src/spotify_scraper/_async/client.py
+++ b/src/spotify_scraper/_async/client.py
@@ -13,6 +13,7 @@ from collections.abc import Awaitable, Callable, Mapping, Sequence
 from pathlib import Path
 from types import TracebackType
 from typing import Any, TypeVar
+from weakref import WeakKeyDictionary
 
 from spotify_scraper import media, urls
 from spotify_scraper.api import lyrics as lyrics_api
@@ -61,8 +62,9 @@ class AsyncSpotifyClient:
         "_closed",
         "_cookies",
         "_lyrics_tokens",
+        "_max_concurrency",
         "_owns_transport",
-        "_semaphore",
+        "_semaphores",
         "_tokens",
         "_transport",
     )
@@ -106,7 +108,14 @@ class AsyncSpotifyClient:
         """
         if max_concurrency < 1:
             raise ValueError("max_concurrency must be at least 1")
-        self._semaphore = asyncio.Semaphore(max_concurrency)
+        self._max_concurrency = max_concurrency
+        # One semaphore per running event loop: an asyncio.Semaphore binds to the
+        # loop it first suspends on, so a single shared instance would raise
+        # "bound to a different event loop" when the client is reused across
+        # asyncio.run() boundaries. The weak keys let finished loops be collected.
+        self._semaphores: WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Semaphore] = (
+            WeakKeyDictionary()
+        )
         if transport is None:
             self._transport: AsyncTransport = AsyncHttpxTransport(
                 rate_limit=rate_limit,
@@ -418,12 +427,26 @@ class AsyncSpotifyClient:
             values, lambda value: self.get_show(value, max_episodes=max_episodes)
         )
 
+    def _loop_semaphore(self) -> asyncio.Semaphore:
+        """Return this client's concurrency semaphore for the running loop.
+
+        Created lazily per event loop and cached weakly, so overlapping batches
+        on the same loop share one budget while reuse across separate
+        ``asyncio.run()`` calls never hits a cross-loop binding error.
+        """
+        loop = asyncio.get_running_loop()
+        semaphore = self._semaphores.get(loop)
+        if semaphore is None:
+            semaphore = asyncio.Semaphore(self._max_concurrency)
+            self._semaphores[loop] = semaphore
+        return semaphore
+
     async def _batch(
         self, values: Sequence[str], fetch: Callable[[str], Awaitable[_T]]
     ) -> Sequence[BatchItem[_T]]:
         """Fetch every value concurrently, bounded by ``max_concurrency``.
 
-        Each per-item coroutine is gated by the shared per-client semaphore, so
+        Each per-item coroutine is gated by this client's per-loop semaphore, so
         the number of in-flight entity pipelines never exceeds the configured
         limit while the :class:`AsyncTokenBucket` still governs request rate.
         Order is preserved by :func:`asyncio.gather`. Only
@@ -432,9 +455,10 @@ class AsyncSpotifyClient:
         batch.
         """
         self._ensure_open()
+        semaphore = self._loop_semaphore()
 
         async def one(value: str) -> BatchItem[_T]:
-            async with self._semaphore:
+            async with semaphore:
                 try:
                     return BatchItem(value, result=await fetch(value))
                 except SpotifyScraperError as exc:

--- a/src/spotify_scraper/_sync/client.py
+++ b/src/spotify_scraper/_sync/client.py
@@ -9,7 +9,7 @@ provider, and delegates all parsing to the sans-io helpers in
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from types import TracebackType
 from typing import Any, TypeVar
@@ -20,6 +20,7 @@ from spotify_scraper.api import parse_embed, parse_entities, pathfinder
 from spotify_scraper.api.parse_embed import EmbedSession
 from spotify_scraper.auth.anonymous import AnonymousTokenProvider
 from spotify_scraper.auth.cookies import CookieTokenProvider, load_sp_dc
+from spotify_scraper.batch import BatchItem
 from spotify_scraper.errors import (
     AuthenticationError,
     NetworkError,
@@ -295,6 +296,127 @@ class SpotifyClient:
         if not tier1:
             return show
         return self._with_episodes(show, entity_id, session, max_episodes)
+
+    def get_tracks(self, values: Sequence[str]) -> Sequence[BatchItem[Track]]:
+        """Fetch many tracks, one ordered :class:`BatchItem` per input.
+
+        Args:
+            values: Spotify track URLs, URIs, or 22-character IDs.
+
+        Returns:
+            An ordered sequence of :class:`BatchItem`, index-aligned with
+            ``values``; a per-item :class:`SpotifyScraperError` is captured in
+            ``error`` and never raised mid-batch.
+
+        Raises:
+            SpotifyScraperError: Only if the client is already closed.
+        """
+        return self._batch(values, self.get_track)
+
+    def get_albums(self, values: Sequence[str]) -> Sequence[BatchItem[Album]]:
+        """Fetch many albums, one ordered :class:`BatchItem` per input.
+
+        Args:
+            values: Spotify album URLs, URIs, or 22-character IDs.
+
+        Returns:
+            An ordered sequence of :class:`BatchItem`, index-aligned with
+            ``values``; a per-item :class:`SpotifyScraperError` is captured in
+            ``error`` and never raised mid-batch.
+
+        Raises:
+            SpotifyScraperError: Only if the client is already closed.
+        """
+        return self._batch(values, self.get_album)
+
+    def get_artists(self, values: Sequence[str]) -> Sequence[BatchItem[Artist]]:
+        """Fetch many artists, one ordered :class:`BatchItem` per input.
+
+        Args:
+            values: Spotify artist URLs, URIs, or 22-character IDs.
+
+        Returns:
+            An ordered sequence of :class:`BatchItem`, index-aligned with
+            ``values``; a per-item :class:`SpotifyScraperError` is captured in
+            ``error`` and never raised mid-batch.
+
+        Raises:
+            SpotifyScraperError: Only if the client is already closed.
+        """
+        return self._batch(values, self.get_artist)
+
+    def get_episodes(self, values: Sequence[str]) -> Sequence[BatchItem[Episode]]:
+        """Fetch many episodes, one ordered :class:`BatchItem` per input.
+
+        Args:
+            values: Spotify episode URLs, URIs, or 22-character IDs.
+
+        Returns:
+            An ordered sequence of :class:`BatchItem`, index-aligned with
+            ``values``; a per-item :class:`SpotifyScraperError` is captured in
+            ``error`` and never raised mid-batch.
+
+        Raises:
+            SpotifyScraperError: Only if the client is already closed.
+        """
+        return self._batch(values, self.get_episode)
+
+    def get_playlists(
+        self, values: Sequence[str], *, max_tracks: int | None = 100
+    ) -> Sequence[BatchItem[Playlist]]:
+        """Fetch many playlists, one ordered :class:`BatchItem` per input.
+
+        Args:
+            values: Spotify playlist URLs, URIs, or 22-character IDs.
+            max_tracks: Forwarded to each :meth:`get_playlist`; ``None`` fetches
+                all tracks.
+
+        Returns:
+            An ordered sequence of :class:`BatchItem`, index-aligned with
+            ``values``; a per-item :class:`SpotifyScraperError` is captured in
+            ``error`` and never raised mid-batch.
+
+        Raises:
+            SpotifyScraperError: Only if the client is already closed.
+        """
+        return self._batch(values, lambda value: self.get_playlist(value, max_tracks=max_tracks))
+
+    def get_shows(
+        self, values: Sequence[str], *, max_episodes: int | None = 50
+    ) -> Sequence[BatchItem[Show]]:
+        """Fetch many shows, one ordered :class:`BatchItem` per input.
+
+        Args:
+            values: Spotify show URLs, URIs, or 22-character IDs.
+            max_episodes: Forwarded to each :meth:`get_show`; ``None`` fetches
+                all episodes.
+
+        Returns:
+            An ordered sequence of :class:`BatchItem`, index-aligned with
+            ``values``; a per-item :class:`SpotifyScraperError` is captured in
+            ``error`` and never raised mid-batch.
+
+        Raises:
+            SpotifyScraperError: Only if the client is already closed.
+        """
+        return self._batch(values, lambda value: self.get_show(value, max_episodes=max_episodes))
+
+    def _batch(self, values: Sequence[str], fetch: Callable[[str], _T]) -> Sequence[BatchItem[_T]]:
+        """Fetch every value sequentially, capturing per-item library errors.
+
+        The per-host :class:`TokenBucket` throttles each underlying request, so
+        a sequential loop is already rate-limited without threads. Only
+        :class:`SpotifyScraperError` is captured per item; anything else
+        (cancellation, programming bugs) propagates and aborts the batch.
+        """
+        self._ensure_open()
+        out: list[BatchItem[_T]] = []
+        for value in values:
+            try:
+                out.append(BatchItem(value, result=fetch(value)))
+            except SpotifyScraperError as exc:
+                out.append(BatchItem(value, error=exc))
+        return out
 
     def get_lyrics(self, value: str) -> Lyrics:
         """Fetch a track's lyrics using the cookie-derived web-player token.

--- a/src/spotify_scraper/batch.py
+++ b/src/spotify_scraper/batch.py
@@ -1,0 +1,56 @@
+"""Sans-io result type for the plural batch helpers.
+
+:class:`BatchItem` is the load-bearing partial-failure wrapper returned by the
+plural ``get_*s`` helpers on both client facades. It echoes the input ``value``
+back alongside either the fetched model (``result``) or the captured library
+error (``error``), so a single dead or malformed input never aborts the batch.
+
+This is a *control wrapper*, not Spotify data, so it deliberately carries no
+``to_dict()`` — the JSON-safe rule applies to entity models, not to this.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+_T = TypeVar("_T")
+
+
+@dataclass(frozen=True, slots=True)
+class BatchItem(Generic[_T]):
+    """One ordered, index-aligned outcome from a plural batch helper.
+
+    Exactly one of ``result`` / ``error`` is populated: the model on success,
+    or the captured :class:`~spotify_scraper.errors.SpotifyScraperError` on
+    failure. The input ``value`` is echoed back so callers can correlate the
+    outcome with the input even after reordering or deduplication.
+
+    Attributes:
+        value: The input URL, URI, or ID, echoed back.
+        result: The fetched model on success, else ``None``.
+        error: The captured exception on failure, else ``None``.
+    """
+
+    value: str
+    result: _T | None = None
+    error: Exception | None = None
+
+    @property
+    def ok(self) -> bool:
+        """Whether the fetch succeeded (``error is None``)."""
+        return self.error is None
+
+    def unwrap(self) -> _T:
+        """Return the model on success, or re-raise the captured error.
+
+        Returns:
+            The fetched model when this item succeeded.
+
+        Raises:
+            Exception: The captured error when this item failed.
+        """
+        if self.error is not None:
+            raise self.error
+        assert self.result is not None  # noqa: S101
+        return self.result

--- a/tests/unit/test_client_batch.py
+++ b/tests/unit/test_client_batch.py
@@ -1,0 +1,226 @@
+"""respx-driven tests for the synchronous client's plural batch helpers.
+
+Reuses the embed/pathfinder fixture harness from
+:mod:`tests.unit.test_client_entities`. Covers the happy path, partial
+failure (one 404 captured, order preserved, no raise), malformed input
+captured as a :class:`URLError`, fail-fast on a closed client,
+:meth:`BatchItem.unwrap`, and cap forwarding for playlists/shows.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs
+
+import httpx
+import pytest
+import respx
+
+from spotify_scraper import SpotifyClient
+from spotify_scraper.errors import NotFoundError, SpotifyScraperError, URLError
+from spotify_scraper.models.track import Track
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+PATHFINDER_RE = re.compile(r"https://api-partner\.spotify\.com/pathfinder/v1/query.*")
+
+IDS: dict[str, str] = {
+    "album": "4aawyAB9vmqN3uQ7FjRGTy",
+    "artist": "0gxyHStUsqpMadRV0Di1Qt",
+    "playlist": "37i9dQZF1DXcBWIGoYBM5M",
+    "episode": "07gKzPFkbvGF0cHoeG7ARS",
+    "show": "4rOoJ6Egrf8K2IrywzwOMk",
+    "track": "2QjOHCTQ1Jl3zawyYOpxh6",
+}
+
+
+def _embed_next_data(kind: str) -> dict[str, Any]:
+    return json.loads((FIXTURES / "embed" / f"{kind}.json").read_text())
+
+
+def _pathfinder_body(kind: str) -> dict[str, Any]:
+    return json.loads((FIXTURES / "pathfinder" / f"{kind}.json").read_text())
+
+
+def _embed_url(kind: str, entity_id: str) -> str:
+    return f"https://open.spotify.com/embed/{kind}/{entity_id}"
+
+
+def _embed_html(kind: str, *, token: str = "EMBED_TOKEN") -> str:  # noqa: S107
+    next_data = copy.deepcopy(_embed_next_data(kind))
+    session = next_data["props"]["pageProps"]["state"]["settings"]["session"]
+    session["accessToken"] = token
+    session["accessTokenExpirationTimestampMs"] = 9_999_999_999_999
+    body = json.dumps(next_data)
+    return f'<script id="__NEXT_DATA__" type="application/json">{body}</script>'
+
+
+def _variables(query: str) -> str:
+    return parse_qs(query)["variables"][0]
+
+
+# --------------------------------------------------------------------------- #
+# Happy path
+# --------------------------------------------------------------------------- #
+
+
+@respx.mock
+def test_get_tracks_happy_path_ordered() -> None:
+    ids = [IDS["track"], IDS["album"], IDS["artist"]]  # any valid track IDs
+    for entity_id in ids:
+        respx.get(_embed_url("track", entity_id)).mock(
+            return_value=httpx.Response(200, text=_embed_html("track"))
+        )
+    respx.get(PATHFINDER_RE).mock(return_value=httpx.Response(200, json=_pathfinder_body("track")))
+
+    with SpotifyClient() as client:
+        items = client.get_tracks(ids)
+
+    assert [item.value for item in items] == ids
+    assert all(item.ok for item in items)
+    assert all(isinstance(item.result, Track) for item in items)
+    assert items[0].unwrap().name
+
+
+# --------------------------------------------------------------------------- #
+# Partial failure
+# --------------------------------------------------------------------------- #
+
+
+@respx.mock
+def test_get_tracks_partial_failure_preserves_order() -> None:
+    good = IDS["track"]
+    dead = IDS["album"]  # a syntactically valid but "missing" ID
+    respx.get(_embed_url("track", good)).mock(
+        return_value=httpx.Response(200, text=_embed_html("track"))
+    )
+    respx.get(_embed_url("track", dead)).mock(return_value=httpx.Response(404, text="nope"))
+    respx.get(PATHFINDER_RE).mock(return_value=httpx.Response(200, json=_pathfinder_body("track")))
+
+    with SpotifyClient() as client:
+        items = client.get_tracks([good, dead])
+
+    assert [item.value for item in items] == [good, dead]
+    assert items[0].ok
+    assert isinstance(items[0].result, Track)
+    assert not items[1].ok
+    assert isinstance(items[1].error, NotFoundError)
+    with pytest.raises(NotFoundError):
+        items[1].unwrap()
+
+
+# --------------------------------------------------------------------------- #
+# Malformed input
+# --------------------------------------------------------------------------- #
+
+
+@respx.mock
+def test_get_tracks_malformed_input_captured_as_urlerror() -> None:
+    good = IDS["track"]
+    bad = "not-a-spotify-id"
+    respx.get(_embed_url("track", good)).mock(
+        return_value=httpx.Response(200, text=_embed_html("track"))
+    )
+    respx.get(PATHFINDER_RE).mock(return_value=httpx.Response(200, json=_pathfinder_body("track")))
+
+    with SpotifyClient() as client:
+        items = client.get_tracks([bad, good])
+
+    assert [item.value for item in items] == [bad, good]
+    assert not items[0].ok
+    assert isinstance(items[0].error, URLError)
+    assert items[1].ok
+
+
+# --------------------------------------------------------------------------- #
+# Fail-fast on a closed client
+# --------------------------------------------------------------------------- #
+
+
+def test_get_tracks_closed_client_raises_up_front() -> None:
+    client = SpotifyClient()
+    client.close()
+    with pytest.raises(SpotifyScraperError):
+        client.get_tracks([IDS["track"]])
+
+
+# --------------------------------------------------------------------------- #
+# Cap forwarding
+# --------------------------------------------------------------------------- #
+
+
+def _playlist_page(count: int) -> dict[str, Any]:
+    body = copy.deepcopy(_pathfinder_body("playlist"))
+    template = body["data"]["playlistV2"]["content"]["items"][0]
+    items: list[dict[str, Any]] = []
+    for index in range(count):
+        item = copy.deepcopy(template)
+        item["uid"] = f"uid{index}"
+        item["itemV2"]["data"]["uri"] = f"spotify:track:{index:022d}"
+        item["itemV2"]["data"]["name"] = f"Track {index}"
+        items.append(item)
+    body["data"]["playlistV2"]["content"]["items"] = items
+    body["data"]["playlistV2"]["content"]["totalCount"] = 500
+    return body
+
+
+@respx.mock
+def test_get_playlists_forwards_max_tracks() -> None:
+    respx.get(_embed_url("playlist", IDS["playlist"])).mock(
+        return_value=httpx.Response(200, text=_embed_html("playlist"))
+    )
+    route = respx.get(PATHFINDER_RE).mock(return_value=httpx.Response(200, json=_playlist_page(50)))
+
+    with SpotifyClient() as client:
+        items = client.get_playlists([IDS["playlist"]], max_tracks=10)
+
+    assert items[0].ok
+    # The cap reaches the underlying get_playlist: only 10 of the 50 available
+    # tracks are kept, and pagination stops (a single pathfinder request).
+    assert len(items[0].unwrap().tracks) == 10
+    assert route.call_count == 1
+
+
+def _show_router(metadata: dict[str, Any], *, total: int) -> Any:
+    def _show_episodes_page(offset: int, limit: int) -> dict[str, Any]:
+        body = copy.deepcopy(_pathfinder_body("show_episodes"))
+        node = body["data"]["podcastUnionV2"]["episodesV2"]
+        template = node["items"][0]
+        items: list[dict[str, Any]] = []
+        for index in range(offset, min(offset + limit, total)):
+            item = copy.deepcopy(template)
+            item["entity"]["data"]["uri"] = f"spotify:episode:{index:022d}"
+            item["entity"]["data"]["name"] = f"Episode {index}"
+            items.append(item)
+        node["items"] = items
+        node["totalCount"] = total
+        return body
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        query = request.url.query.decode()
+        operation = parse_qs(query)["operationName"][0]
+        if operation == "queryShowMetadataV2":
+            return httpx.Response(200, json=metadata)
+        variables = json.loads(_variables(query))
+        return httpx.Response(
+            200, json=_show_episodes_page(variables["offset"], variables["limit"])
+        )
+
+    return handler
+
+
+@respx.mock
+def test_get_shows_forwards_max_episodes() -> None:
+    respx.get(_embed_url("show", IDS["show"])).mock(
+        return_value=httpx.Response(200, text=_embed_html("show"))
+    )
+    respx.get(PATHFINDER_RE).mock(side_effect=_show_router(_pathfinder_body("show"), total=2707))
+
+    with SpotifyClient() as client:
+        items = client.get_shows([IDS["show"]], max_episodes=10)
+
+    assert items[0].ok
+    assert len(items[0].unwrap().episodes) == 10

--- a/tests/unit/test_client_batch_async.py
+++ b/tests/unit/test_client_batch_async.py
@@ -311,3 +311,31 @@ async def test_get_tracks_bounded_by_max_concurrency() -> None:
 async def test_max_concurrency_zero_rejected() -> None:
     with pytest.raises(ValueError, match="max_concurrency"):
         AsyncSpotifyClient(max_concurrency=0)
+
+
+class _LoopAgnosticTransport:
+    """A minimal stub with no asyncio state, so it is reusable across loops."""
+
+    async def get(self, url: str, *, headers: Mapping[str, str] | None = None) -> Response:
+        if "pathfinder" in url:
+            return _FakeResponse(200, body=_pathfinder_body("track"))
+        return _FakeResponse(200, text=_embed_html("track"))
+
+    async def aclose(self) -> None:
+        return None
+
+
+def test_async_client_reused_across_event_loops() -> None:
+    # Regression: the per-client concurrency semaphore must be created per running
+    # loop, not bound at construction. max_concurrency=1 forces the semaphore to
+    # suspend a waiter (which is what binds it to a loop), so reusing the client
+    # from a second asyncio.run() would raise "bound to a different event loop".
+    ids = [f"{i:022d}" for i in range(3)]
+    client = AsyncSpotifyClient(transport=_LoopAgnosticTransport(), max_concurrency=1)
+
+    first = asyncio.run(client.get_tracks(ids))
+    second = asyncio.run(client.get_tracks(ids))  # a fresh event loop
+
+    assert all(item.ok for item in first)
+    assert all(item.ok for item in second)
+    assert [item.value for item in second] == ids

--- a/tests/unit/test_client_batch_async.py
+++ b/tests/unit/test_client_batch_async.py
@@ -1,0 +1,313 @@
+"""respx-driven tests for the asynchronous client's plural batch helpers.
+
+A 1:1 mirror of :mod:`tests.unit.test_client_batch` over the async client,
+plus an async-only bounded-concurrency test that injects a recording stub
+transport to prove in-flight entity fetches never exceed ``max_concurrency``
+while still running more than one concurrently, and a ``max_concurrency=0``
+validation test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs
+
+import httpx
+import pytest
+import respx
+
+from spotify_scraper import AsyncSpotifyClient
+from spotify_scraper.errors import NotFoundError, SpotifyScraperError, URLError
+from spotify_scraper.http.transport import Response
+from spotify_scraper.models.track import Track
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+PATHFINDER_RE = re.compile(r"https://api-partner\.spotify\.com/pathfinder/v1/query.*")
+
+IDS: dict[str, str] = {
+    "album": "4aawyAB9vmqN3uQ7FjRGTy",
+    "artist": "0gxyHStUsqpMadRV0Di1Qt",
+    "playlist": "37i9dQZF1DXcBWIGoYBM5M",
+    "episode": "07gKzPFkbvGF0cHoeG7ARS",
+    "show": "4rOoJ6Egrf8K2IrywzwOMk",
+    "track": "2QjOHCTQ1Jl3zawyYOpxh6",
+}
+
+
+def _embed_next_data(kind: str) -> dict[str, Any]:
+    return json.loads((FIXTURES / "embed" / f"{kind}.json").read_text())
+
+
+def _pathfinder_body(kind: str) -> dict[str, Any]:
+    return json.loads((FIXTURES / "pathfinder" / f"{kind}.json").read_text())
+
+
+def _embed_url(kind: str, entity_id: str) -> str:
+    return f"https://open.spotify.com/embed/{kind}/{entity_id}"
+
+
+def _embed_html(kind: str, *, token: str = "EMBED_TOKEN") -> str:  # noqa: S107
+    next_data = copy.deepcopy(_embed_next_data(kind))
+    session = next_data["props"]["pageProps"]["state"]["settings"]["session"]
+    session["accessToken"] = token
+    session["accessTokenExpirationTimestampMs"] = 9_999_999_999_999
+    body = json.dumps(next_data)
+    return f'<script id="__NEXT_DATA__" type="application/json">{body}</script>'
+
+
+def _variables(query: str) -> str:
+    return parse_qs(query)["variables"][0]
+
+
+# --------------------------------------------------------------------------- #
+# Happy path
+# --------------------------------------------------------------------------- #
+
+
+@respx.mock
+async def test_get_tracks_happy_path_ordered() -> None:
+    ids = [IDS["track"], IDS["album"], IDS["artist"]]
+    for entity_id in ids:
+        respx.get(_embed_url("track", entity_id)).mock(
+            return_value=httpx.Response(200, text=_embed_html("track"))
+        )
+    respx.get(PATHFINDER_RE).mock(return_value=httpx.Response(200, json=_pathfinder_body("track")))
+
+    async with AsyncSpotifyClient() as client:
+        items = await client.get_tracks(ids)
+
+    assert [item.value for item in items] == ids
+    assert all(item.ok for item in items)
+    assert all(isinstance(item.result, Track) for item in items)
+    assert items[0].unwrap().name
+
+
+# --------------------------------------------------------------------------- #
+# Partial failure
+# --------------------------------------------------------------------------- #
+
+
+@respx.mock
+async def test_get_tracks_partial_failure_preserves_order() -> None:
+    good = IDS["track"]
+    dead = IDS["album"]
+    respx.get(_embed_url("track", good)).mock(
+        return_value=httpx.Response(200, text=_embed_html("track"))
+    )
+    respx.get(_embed_url("track", dead)).mock(return_value=httpx.Response(404, text="nope"))
+    respx.get(PATHFINDER_RE).mock(return_value=httpx.Response(200, json=_pathfinder_body("track")))
+
+    async with AsyncSpotifyClient() as client:
+        items = await client.get_tracks([good, dead])
+
+    assert [item.value for item in items] == [good, dead]
+    assert items[0].ok
+    assert isinstance(items[0].result, Track)
+    assert not items[1].ok
+    assert isinstance(items[1].error, NotFoundError)
+    with pytest.raises(NotFoundError):
+        items[1].unwrap()
+
+
+# --------------------------------------------------------------------------- #
+# Malformed input
+# --------------------------------------------------------------------------- #
+
+
+@respx.mock
+async def test_get_tracks_malformed_input_captured_as_urlerror() -> None:
+    good = IDS["track"]
+    bad = "not-a-spotify-id"
+    respx.get(_embed_url("track", good)).mock(
+        return_value=httpx.Response(200, text=_embed_html("track"))
+    )
+    respx.get(PATHFINDER_RE).mock(return_value=httpx.Response(200, json=_pathfinder_body("track")))
+
+    async with AsyncSpotifyClient() as client:
+        items = await client.get_tracks([bad, good])
+
+    assert [item.value for item in items] == [bad, good]
+    assert not items[0].ok
+    assert isinstance(items[0].error, URLError)
+    assert items[1].ok
+
+
+# --------------------------------------------------------------------------- #
+# Fail-fast on a closed client
+# --------------------------------------------------------------------------- #
+
+
+async def test_get_tracks_closed_client_raises_up_front() -> None:
+    client = AsyncSpotifyClient()
+    await client.aclose()
+    with pytest.raises(SpotifyScraperError):
+        await client.get_tracks([IDS["track"]])
+
+
+# --------------------------------------------------------------------------- #
+# Cap forwarding
+# --------------------------------------------------------------------------- #
+
+
+def _playlist_page(count: int) -> dict[str, Any]:
+    body = copy.deepcopy(_pathfinder_body("playlist"))
+    template = body["data"]["playlistV2"]["content"]["items"][0]
+    items: list[dict[str, Any]] = []
+    for index in range(count):
+        item = copy.deepcopy(template)
+        item["uid"] = f"uid{index}"
+        item["itemV2"]["data"]["uri"] = f"spotify:track:{index:022d}"
+        item["itemV2"]["data"]["name"] = f"Track {index}"
+        items.append(item)
+    body["data"]["playlistV2"]["content"]["items"] = items
+    body["data"]["playlistV2"]["content"]["totalCount"] = 500
+    return body
+
+
+@respx.mock
+async def test_get_playlists_forwards_max_tracks() -> None:
+    respx.get(_embed_url("playlist", IDS["playlist"])).mock(
+        return_value=httpx.Response(200, text=_embed_html("playlist"))
+    )
+    route = respx.get(PATHFINDER_RE).mock(return_value=httpx.Response(200, json=_playlist_page(50)))
+
+    async with AsyncSpotifyClient() as client:
+        items = await client.get_playlists([IDS["playlist"]], max_tracks=10)
+
+    assert items[0].ok
+    assert len(items[0].unwrap().tracks) == 10
+    assert route.call_count == 1
+
+
+def _show_router(metadata: dict[str, Any], *, total: int) -> Any:
+    def _show_episodes_page(offset: int, limit: int) -> dict[str, Any]:
+        body = copy.deepcopy(_pathfinder_body("show_episodes"))
+        node = body["data"]["podcastUnionV2"]["episodesV2"]
+        template = node["items"][0]
+        items: list[dict[str, Any]] = []
+        for index in range(offset, min(offset + limit, total)):
+            item = copy.deepcopy(template)
+            item["entity"]["data"]["uri"] = f"spotify:episode:{index:022d}"
+            item["entity"]["data"]["name"] = f"Episode {index}"
+            items.append(item)
+        node["items"] = items
+        node["totalCount"] = total
+        return body
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        query = request.url.query.decode()
+        operation = parse_qs(query)["operationName"][0]
+        if operation == "queryShowMetadataV2":
+            return httpx.Response(200, json=metadata)
+        variables = json.loads(_variables(query))
+        return httpx.Response(
+            200, json=_show_episodes_page(variables["offset"], variables["limit"])
+        )
+
+    return handler
+
+
+@respx.mock
+async def test_get_shows_forwards_max_episodes() -> None:
+    respx.get(_embed_url("show", IDS["show"])).mock(
+        return_value=httpx.Response(200, text=_embed_html("show"))
+    )
+    respx.get(PATHFINDER_RE).mock(side_effect=_show_router(_pathfinder_body("show"), total=2707))
+
+    async with AsyncSpotifyClient() as client:
+        items = await client.get_shows([IDS["show"]], max_episodes=10)
+
+    assert items[0].ok
+    assert len(items[0].unwrap().episodes) == 10
+
+
+# --------------------------------------------------------------------------- #
+# Bounded concurrency (async only)
+# --------------------------------------------------------------------------- #
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, *, text: str = "", body: Any = None) -> None:
+        self.status_code = status_code
+        self._text = text
+        self._body = body
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        return {}
+
+    @property
+    def text(self) -> str:
+        return self._text
+
+    @property
+    def content(self) -> bytes:
+        return self._text.encode()
+
+    def json(self) -> Any:
+        return self._body
+
+
+class _ConcurrencyProbeTransport:
+    """Records the peak number of concurrent entity pipelines.
+
+    Each entity pipeline starts with an embed ``get``; that call increments an
+    in-flight counter, waits on a barrier until ``max_concurrency`` pipelines
+    have arrived (deterministic overlap, no sleeps), records the peak, then
+    releases. Subsequent pathfinder ``get`` calls return immediately.
+    """
+
+    def __init__(self, *, expected_batch: int, gate_at: int) -> None:
+        self._gate_at = gate_at
+        self._lock = asyncio.Lock()
+        self._in_flight = 0
+        self.peak_in_flight = 0
+        # Released once gate_at coroutines are simultaneously in flight, or
+        # once every pipeline has started (so the last, smaller wave proceeds).
+        self._release = asyncio.Event()
+        self._started = 0
+        self._expected = expected_batch
+
+    async def get(self, url: str, *, headers: Mapping[str, str] | None = None) -> Response:
+        if "pathfinder" in url:
+            return _FakeResponse(200, body=_pathfinder_body("track"))
+        # Embed request: this is the entry point of one entity pipeline.
+        async with self._lock:
+            self._in_flight += 1
+            self._started += 1
+            self.peak_in_flight = max(self.peak_in_flight, self._in_flight)
+            if self._in_flight >= self._gate_at or self._started >= self._expected:
+                self._release.set()
+        await self._release.wait()
+        async with self._lock:
+            self._in_flight -= 1
+            if self._in_flight == 0:
+                self._release.clear()
+        return _FakeResponse(200, text=_embed_html("track"))
+
+    async def aclose(self) -> None:
+        return None
+
+
+async def test_get_tracks_bounded_by_max_concurrency() -> None:
+    ids = [f"{i:022d}" for i in range(8)]
+    transport = _ConcurrencyProbeTransport(expected_batch=len(ids), gate_at=2)
+    client = AsyncSpotifyClient(transport=transport, max_concurrency=2)
+    items = await client.get_tracks(ids)
+
+    assert [item.value for item in items] == ids
+    assert all(item.ok for item in items)
+    # The semaphore bounds fan-out but does not serialize it.
+    assert transport.peak_in_flight <= 2
+    assert transport.peak_in_flight > 1
+
+
+async def test_max_concurrency_zero_rejected() -> None:
+    with pytest.raises(ValueError, match="max_concurrency"):
+        AsyncSpotifyClient(max_concurrency=0)


### PR DESCRIPTION
Implements #132 (v3.5). Spec-first: `openspec/changes/add-batch-helpers/`. Independent ergonomics — branches off `master`.

Six plural getters on both clients (`get_tracks`/`get_albums`/`get_artists`/`get_playlists`/`get_episodes`/`get_shows`) that fetch many IDs in one call. **Pure orchestration** of the existing getters — no new endpoint, no new dependency, no parser/model/transport change.

- Returns an ordered `Sequence[BatchItem[_T]]` (sans-io frozen generic, `.ok`/`.unwrap()`), so a 404 or bad ID on one item never kills the batch.
- **Sync**: sequential loop (already throttled by the per-host `TokenBucket`). **Async**: `asyncio.gather` bounded by `asyncio.Semaphore(max_concurrency=5)` — an async-only constructor arg, so the six plural signatures stay byte-identical across clients.

**Fully verified — not a draft:** ✅ 585 passed · mypy --strict clean · 91.13% coverage (`batch.py` 100%) · **parity guard green** · async concurrency bound is deterministically tested (peak in-flight ≤ max_concurrency, >1 concurrent). Core modules untouched.

Closes #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)