### PR TITLE
Add a global --no-hint CLI option

### DIFF
--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -26,6 +26,8 @@ spotifyscraper --version
 spotifyscraper --help
 ```
 
+Pass `--no-hint` before the command to suppress the one-time star hint for that invocation.
+
 ## Entity commands
 
 Each entity type has a command that accepts a Spotify **URL**, **URI**, or bare

--- a/src/spotify_scraper/cli/main.py
+++ b/src/spotify_scraper/cli/main.py
@@ -101,8 +101,14 @@ def main(
             callback=_version_callback,
         ),
     ] = False,
+    no_hint: Annotated[
+        bool,
+        typer.Option("--no-hint", help="Suppress the one-time star hint."),
+    ] = False,
 ) -> None:
     """SpotifyScraper command-line interface."""
+    if no_hint:
+        os.environ["SPOTIFYSCRAPER_NO_HINT"] = "1"
 
 
 @app.command()

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -8,6 +8,7 @@ model instances, so each command is exercised end-to-end through Typer's
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -268,6 +269,13 @@ def test_help_lists_commands() -> None:
     assert result.exit_code == 0
     for command in ("track", "album", "artist", "playlist", "show", "episode", "download"):
         assert command in result.stdout
+
+
+def test_no_hint_sets_opt_out_before_command_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SPOTIFYSCRAPER_NO_HINT", raising=False)
+    result = runner.invoke(app, ["--no-hint", "track", "x"])
+    assert result.exit_code == 0, result.output
+    assert os.environ["SPOTIFYSCRAPER_NO_HINT"] == "1"
 
 
 # --- Download commands ---------------------------------------------------------


### PR DESCRIPTION
Closes #143

Adds `--no-hint` as a global CLI option and routes it through the existing `SPOTIFYSCRAPER_NO_HINT` switch. The flag is applied before the command runs, so the usual upgrade hint stays quiet for that invocation.

The CLI guide and a regression test are included.

Tested with:
- `make lint`
- `make type`
- `make test`